### PR TITLE
feat(redteam-agent): implement Metasploit Framework integration via MSF RPC

### DIFF
--- a/service/redteam_agent/agent.py
+++ b/service/redteam_agent/agent.py
@@ -4,7 +4,7 @@ from langchain_ollama import ChatOllama
 from langchain_core.messages import AnyMessage, SystemMessage, ToolMessage, HumanMessage
 from langgraph.graph import StateGraph, START, END
 from .config import config
-from .tools import retrieve_context, execute_nmap_scan
+from .tools import retrieve_context, execute_nmap_scan, execute_msf_module
 
 # Define state
 class MessagesState(TypedDict):
@@ -21,7 +21,7 @@ class RedTeamAgent:
         self.app = self._build_graph()
 
     def _init_tools(self):
-        self.tools = [retrieve_context, execute_nmap_scan]
+        self.tools = [retrieve_context, execute_nmap_scan, execute_msf_module]
         self.tools_by_name = {tool.name: tool for tool in self.tools}
 
     def _init_models(self):

--- a/service/redteam_agent/config.py
+++ b/service/redteam_agent/config.py
@@ -31,21 +31,45 @@ class RAGConfig:
     COLLECTION_NAME = os.getenv("COLLECTION_NAME", "example_collection")
     RETRIEVER_K = int(os.getenv("RETRIEVER_K", "5"))
 
+    # Metasploit RPC Configuration
+    # Ensure you start msfrpcd with: msfrpcd -P password -S false -U msf -a 127.0.0.1
+    MSF_RPC_HOST = os.getenv("MSF_RPC_HOST", "172.31.191.206")
+    MSF_RPC_PORT = int(os.getenv("MSF_RPC_PORT", "55552"))
+    MSF_RPC_USER = os.getenv("MSF_RPC_USER", "msf")
+    MSF_RPC_PASS = os.getenv("MSF_RPC_PASS", "msf123")
+    MSF_RPC_SSL = os.getenv("MSF_RPC_SSL", "False").lower() == "true"
+
     LLM_SYSTEM_PROMPT = """You are a Security Research & Execution Assistant. 
 You convert user intent into technical actions using provided documentation and execution tools.
 
+Available Tools:
+- `retrieve_context` — Search documentation / guides.
+- `execute_nmap_scan` — Run an Nmap scan.
+- `execute_msf_module` — Run a Metasploit auxiliary scanner or exploit module via MSF RPC.
+
+Workflow:
+1. **Reconnaissance**: Call `retrieve_context` to find technical specifications.
+2. **Scanning**: Call `execute_nmap_scan` with the verified command.
+3. **Verification / Exploitation** (when applicable): Analyse the Nmap output.
+   - If open services or potential vulnerabilities are found, call `execute_msf_module` to verify them.
+   - For example, if Nmap shows port 80 is open, you can run `execute_msf_module` with
+     module_type='auxiliary', module_name='scanner/http/http_version',
+     options={'RHOSTS': '<target>', 'RPORT': 80}.
+   - For exploit modules you can similarly call `execute_msf_module` with module_type='exploit'.
+4. **Output Analysis**: After running a Metasploit module, carefully read the console output to
+   determine whether the vulnerability is confirmed, e.g., look for version banners, session
+   creation, or "[+]" success indicators.
+
 Rules:
-1. Tool-Driven Protocol: 
-   - Step 1: Call `retrieve_context` to find technical specifications.
-   - Step 2: Once specs are found, call `execute_nmap_scan` with the verified command.
-2. Fact Supremacy: Documentation context > Internal memory. If the guide says a flag is incompatible, you MUST follow it.
-3. The logic for the command must strictly adhere to the documentation provided.
-4. Constraint Transparency: Before generating any command, explicitly list which flags/scan types are DISALLOWED for the requested technique.
+1. Fact Supremacy: Documentation context > Internal memory. If the guide says a flag is incompatible, you MUST follow it.
+2. The logic for the command must strictly adhere to the documentation provided.
+3. Constraint Transparency: Before generating any command, explicitly list which flags/scan types are DISALLOWED for the requested technique.
 
 Final Response Output Format:
 - **Explanation**: [Summary from manual]
-- **Command**: [Executed Command]
-- **Execution Result**: [Execution Output]"""
+- **Command(s) Executed**: [Nmap command and/or MSF module used]
+- **Execution Result**: [Output]
+- **Vulnerability Assessment**: [Confirmed / Not confirmed / Needs further investigation]"""
 
     CRITIC_SYSTEM_PROMPT = """You are a Senior Security Auditor. 
 Your task is to cross-check a proposed Nmap command against the provided documentation context.

--- a/service/redteam_agent/tools.py
+++ b/service/redteam_agent/tools.py
@@ -1,5 +1,8 @@
 import subprocess
+import time
 from langchain.tools import tool
+from pymetasploit3.msfrpc import MsfRpcClient
+from .config import config
 from .vector_store import get_vector_store
 
 @tool(response_format="content_and_artifact")
@@ -50,3 +53,108 @@ def execute_nmap_scan(command: str):
         return "Error: Nmap scan timed out (limit: 300s)."
     except Exception as e:
         return f"System Error executing nmap: {str(e)}"
+
+@tool
+def execute_msf_module(module_type: str, module_name: str, options: dict):
+    """Execute a Metasploit module (auxiliary or exploit) via MSF RPC and return its console output.
+
+    Use this tool to follow up on Nmap findings — for example, to verify a
+    vulnerability with an auxiliary scanner or attempt a basic exploit.
+
+    Args:
+        module_type: Type of module (e.g., 'auxiliary', 'exploit').
+        module_name: Full module path (e.g., 'scanner/http/http_version').
+        options: Dictionary of module options (e.g., {'RHOSTS': '10.0.0.1', 'RPORT': 80}).
+    """
+    try:
+        # --- 1. Connect to MSF RPC ---
+        ssl_setting = config.MSF_RPC_SSL
+        if isinstance(ssl_setting, str):
+            ssl_setting = ssl_setting.lower() == 'true'
+
+        client = MsfRpcClient(
+            password=config.MSF_RPC_PASS,
+            username=config.MSF_RPC_USER,
+            server=config.MSF_RPC_HOST,
+            port=config.MSF_RPC_PORT,
+            ssl=ssl_setting,
+        )
+
+        # --- 2. Validate module exists ---
+        module = client.modules.use(module_type, module_name)
+        if not module:
+            return f"Error: Module '{module_type}/{module_name}' not found."
+
+        # --- 3. Build the console command string ---
+        console_cmd = f"use {module_type}/{module_name}\n"
+        for key, value in options.items():
+            if key not in module.options:
+                return (
+                    f"Error: Invalid option '{key}' for module '{module_name}'. "
+                    f"Valid options: {list(module.options)}"
+                )
+            console_cmd += f"set {key} {value}\n"
+        # 'run' works for both auxiliary and exploit modules in msfconsole
+        console_cmd += "run\n"
+
+        # --- 4. Create an interactive console and send the command ---
+        console = client.consoles.console()
+        console.write(console_cmd)
+
+        # --- 5. Poll until the console is no longer busy ---
+        output_parts: list[str] = []
+        poll_interval = 2          # seconds between polls
+        max_wait      = 120        # total seconds before timeout
+        elapsed       = 0
+
+        while elapsed < max_wait:
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+            res = console.read()
+            if res["data"]:
+                output_parts.append(res["data"])
+            if res["busy"] is False:
+                break
+        else:
+            # Timed-out — still collect whatever we have
+            output_parts.append("\n[WARNING] Module execution timed out (120 s).")
+
+        # --- 6. Destroy the console to free resources ---
+        try:
+            console.destroy()
+        except Exception:
+            pass  # best-effort cleanup
+
+        full_output = "".join(output_parts).strip()
+
+        # --- 7. Check for new sessions (exploit follow-up) ---
+        session_info = ""
+        try:
+            sessions = client.sessions.list
+            if sessions:
+                session_info = f"\n\n[+] Active sessions ({len(sessions)}):\n"
+                for sid, sdata in sessions.items():
+                    session_info += (
+                        f"  Session {sid}: type={sdata.get('type')} "
+                        f"target={sdata.get('session_host')}:{sdata.get('session_port')} "
+                        f"info={sdata.get('info')}\n"
+                    )
+        except Exception:
+            pass  # non-critical
+
+        if not full_output:
+            return (
+                f"Module {module_type}/{module_name} executed but produced no console output."
+                f"{session_info}"
+            )
+
+        return f"Metasploit Output:\n{full_output}{session_info}"
+
+    except Exception as e:
+        return (
+            f"System Error executing Metasploit: {str(e)}\n"
+            f"Ensure msfrpcd is running: "
+            f"'msfrpcd -P {config.MSF_RPC_PASS} -S {str(ssl_setting).lower()} "
+            f"-U {config.MSF_RPC_USER} -a 0.0.0.0'"
+        )
+

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -7,3 +7,4 @@ chromadb==1.4.0
 python-dotenv
 pdfplumber
 fastmcp
+pymetasploit3

--- a/service/test_msf.py
+++ b/service/test_msf.py
@@ -1,0 +1,50 @@
+
+import sys
+import os
+import time
+
+# Add current directory to path so we can import 'redteam_agent' package
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../")
+
+from service.redteam_agent.tools import execute_msf_module
+from service.redteam_agent.config import config
+
+def test_msf_connection():
+    print("=== Testing MSF RPC Connection ===")
+    print(f"Connecting to {config.MSF_RPC_HOST}:{config.MSF_RPC_PORT} as user '{config.MSF_RPC_USER}'...")
+
+    # We can try to use a harmless auxiliary module just to see if we can connect and set options.
+    # 'auxiliary/scanner/portscan/tcp' is a good candidate.
+    
+    module_type = "auxiliary"
+    module_name = "scanner/portscan/tcp"
+    
+    # Intentionally picking a safe target (localhost) and a single port to avoid noise
+    target_options = {
+        "RHOSTS": "127.0.0.1",
+        "PORTS": "135" # Common windows port, or just pick random
+    }
+    
+    print(f"Attempting to load module: {module_type}/{module_name}")
+    print(f"Options: {target_options}")
+    
+    try:
+        result = execute_msf_module.invoke({
+            "module_type": module_type,
+            "module_name": module_name,
+            "options": target_options
+        })
+        
+        print("\n[Tool Output]:")
+        print(result)
+        
+        if "Error" in result:
+            print("\n❌ Test Failed.")
+        else:
+            print("\n✅ Test Passed: Module executed via RPC.")
+            
+    except Exception as e:
+        print(f"\n❌ Exception during test: {e}")
+
+if __name__ == "__main__":
+    test_msf_connection()


### PR DESCRIPTION
Add execute_msf_module tool to extend agent capabilities with exploitation and vulnerability verification using pymetasploit3.

- tools.py: Add execute_msf_module() connecting to msfrpcd via RPC, supporting auxiliary scanners and basic exploits with output polling and session detection
- config.py: Add MSF RPC connection settings and update LLM system prompt with MSF workflow and Vulnerability Assessment output format
- agent.py: Register execute_msf_module in agent tool list
- requirements.txt: Add pymetasploit3 dependency
- test_msf.py: Add integration test for MSF RPC connectivity

Closes #37