### PR TITLE
Project scope configuration converted to project workspace and dashbo…

### DIFF
--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-router-dom": "^7.13.1",
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
@@ -2011,6 +2012,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3183,11 +3197,50 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/resolve-from": {
@@ -3259,6 +3312,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-router-dom": "^7.13.1",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {

--- a/frontend/web/src/App.jsx
+++ b/frontend/web/src/App.jsx
@@ -1,75 +1,111 @@
 import { useState } from 'react'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import EmailEntry from './pages/EmailEntry'
 import TermsModal from './pages/TermsModal'
-import ProjectScopeManager from './pages/ProjectScopeManager'
+import HowItWorks from './pages/HowItWorks'
+import DashboardHome from './pages/DashboardHome'
+import ProjectWorkspace from './pages/ProjectWorkspace'
 import Dashboard from './pages/Dashboard'
+import TopNav from './components/TopNav'
 import { setAuthUserId } from './lib/api'
-import './App.css'
 
-// Main App Component
-// Routing flow: email -> terms-agreement -> project-scope -> dashboard
+// Auth flow:  login → terms → guide → app (react-router routes)
+// Pre-auth states are managed with useState (they are transient and don't
+// benefit from URL routing — a page refresh during login resets to login anyway).
 function App() {
-  const [currentPage, setCurrentPage] = useState('email')
-  const [username, setUsername] = useState('')
-  const [email, setEmail] = useState('')
-  const [scanType, setScanType] = useState('')
-  const [targets, setTargets] = useState([])
-  const [projectId, setProjectId] = useState(null)
+  const [authState, setAuthState] = useState('login')
+  const [username, setUsername]   = useState('')
+  const [email, setEmail]         = useState('')
 
-  // onVerify now receives (username, email, userId) from EmailEntry.
-  // We store userId in the api module so every subsequent request includes X-User-Id.
   const handleVerify = (name, userEmail, userId) => {
     setAuthUserId(userId)
     setUsername(name)
     setEmail(userEmail)
-    setCurrentPage('terms-agreement')
+    setAuthState('terms')
   }
 
-  const handleTermsAccepted = () => {
-    setCurrentPage('project-scope')
-  }
+  const handleTermsAccepted = () => setAuthState('guide')
 
   const handleTermsDeclined = () => {
-    setCurrentPage('email')
+    setAuthState('login')
     setUsername('')
     setEmail('')
   }
 
-  // ProjectScopeManager passes (scanType, targetValues, projectId)
-  const handleStartScan = (type, targetList, projId) => {
-    setScanType(type)
-    setTargets(targetList)
-    setProjectId(projId ?? null)
-    setCurrentPage('dashboard')
+  const handleGuideComplete = () => setAuthState('app')
+
+  const handleSignOut = () => {
+    setAuthState('login')
+    setUsername('')
+    setEmail('')
+    setAuthUserId(null)
   }
 
+  // ── Pre-auth screens ──────────────────────────────────────────────────────
+  if (authState === 'login') {
+    return <EmailEntry onVerify={handleVerify} />
+  }
+
+  if (authState === 'terms') {
+    return (
+      <TermsModal
+        username={username}
+        email={email}
+        onAccept={handleTermsAccepted}
+        onDecline={handleTermsDeclined}
+      />
+    )
+  }
+
+  if (authState === 'guide') {
+    return <HowItWorks onComplete={handleGuideComplete} />
+  }
+
+  // ── Authenticated app — react-router takes over ───────────────────────────
   return (
-    <div>
-      {currentPage === 'email' ? (
-        <EmailEntry onVerify={handleVerify} />
-      ) : currentPage === 'terms-agreement' ? (
-        <TermsModal
-          username={username}
-          email={email}
-          onAccept={handleTermsAccepted}
-          onDecline={handleTermsDeclined}
-        />
-      ) : currentPage === 'project-scope' ? (
-        <ProjectScopeManager
-          username={username}
-          email={email}
-          onStartScan={handleStartScan}
-        />
-      ) : (
-        <Dashboard
-          username={username}
-          email={email}
-          targets={targets}
-          scanType={scanType}
-          projectId={projectId}
-        />
-      )}
-    </div>
+    <Routes>
+      <Route path="/" element={<Navigate to="/dashboard" replace />} />
+
+      <Route
+        path="/dashboard"
+        element={
+          <>
+            <TopNav username={username} onSignOut={handleSignOut} />
+            <DashboardHome username={username} />
+          </>
+        }
+      />
+
+      <Route
+        path="/guide"
+        element={
+          <>
+            <TopNav username={username} onSignOut={handleSignOut} />
+            {/* Standalone guide — no onComplete prop, shows "Back to Dashboard" CTA */}
+            <HowItWorks />
+          </>
+        }
+      />
+
+      <Route
+        path="/projects/:projectId"
+        element={
+          <>
+            <TopNav username={username} onSignOut={handleSignOut} />
+            <ProjectWorkspace username={username} />
+          </>
+        }
+      />
+
+      {/* Full-screen scan terminal — no TopNav chrome */}
+      <Route
+        path="/projects/:projectId/runs/:runId"
+        element={<Dashboard />}
+      />
+
+      {/* Catch-all redirect */}
+      <Route path="*" element={<Navigate to="/dashboard" replace />} />
+    </Routes>
   )
 }
 

--- a/frontend/web/src/components/TopNav.jsx
+++ b/frontend/web/src/components/TopNav.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+export default function TopNav({ username, onSignOut }) {
+  const location = useLocation();
+  const [dropdownOpen, setDropdownOpen] = React.useState(false);
+  const dropdownRef = React.useRef(null);
+
+  const initials = username ? username.slice(0, 2).toUpperCase() : '??';
+
+  // Close dropdown when clicking outside
+  React.useEffect(() => {
+    function handleClick(e) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  return (
+    <nav
+      style={{ background: '#0a0e14', borderBottom: '1px solid var(--rt-border)' }}
+      className="sticky top-0 z-50 flex items-center gap-6 px-6"
+      aria-label="Global navigation"
+    >
+      {/* Logo */}
+      <Link
+        to="/dashboard"
+        className="py-4 font-mono font-bold text-[15px] tracking-tight whitespace-nowrap no-underline"
+        style={{ color: 'var(--rt-flame)' }}
+      >
+        ⬡ AI RedTeam
+      </Link>
+
+      {/* Nav links */}
+      <div className="flex items-center flex-1">
+        <NavLink to="/dashboard" active={location.pathname === '/dashboard'}>
+          Dashboard
+        </NavLink>
+        <NavLink to="/guide" active={location.pathname === '/guide'}>
+          Guide
+        </NavLink>
+      </div>
+
+      {/* User area */}
+      <div className="relative flex items-center gap-3" ref={dropdownRef}>
+        <span className="text-xs" style={{ color: 'var(--rt-muted)' }}>
+          {username}
+        </span>
+        <button
+          onClick={() => setDropdownOpen(o => !o)}
+          className="w-8 h-8 rounded-full flex items-center justify-center font-mono text-xs font-bold text-white flex-shrink-0 focus:outline-none"
+          style={{ background: 'linear-gradient(135deg, var(--rt-flame) 0%, var(--rt-orchid) 100%)' }}
+          aria-label="User menu"
+        >
+          {initials}
+        </button>
+
+        {/* Dropdown */}
+        {dropdownOpen && (
+          <div
+            className="absolute right-0 top-10 w-48 rounded-lg overflow-hidden shadow-2xl z-50"
+            style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+          >
+            <div
+              className="px-4 py-3"
+              style={{ borderBottom: '1px solid var(--rt-border)' }}
+            >
+              <p className="text-sm font-semibold" style={{ color: 'var(--rt-text)' }}>{username}</p>
+              <p className="text-xs font-mono" style={{ color: 'var(--rt-muted)' }}>analyst</p>
+            </div>
+            <button
+              className="w-full text-left px-4 py-3 text-sm transition-colors hover:bg-[var(--rt-surface2)]"
+              style={{ color: 'var(--rt-muted)' }}
+              onClick={() => setDropdownOpen(false)}
+            >
+              Account Settings
+              <span className="ml-2 text-xs opacity-50">(coming soon)</span>
+            </button>
+            <button
+              className="w-full text-left px-4 py-3 text-sm transition-colors hover:bg-[var(--rt-surface2)]"
+              style={{ color: 'var(--rt-ember)', borderTop: '1px solid var(--rt-border)' }}
+              onClick={() => { setDropdownOpen(false); onSignOut?.(); }}
+            >
+              Sign Out
+            </button>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}
+
+function NavLink({ to, active, children }) {
+  return (
+    <Link
+      to={to}
+      className="px-4 py-[14px] text-xs font-semibold uppercase tracking-widest transition-colors no-underline"
+      style={{
+        color: active ? 'var(--rt-sky)' : 'var(--rt-muted)',
+        borderBottom: active ? '2px solid var(--rt-sky)' : '2px solid transparent',
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/frontend/web/src/index.css
+++ b/frontend/web/src/index.css
@@ -1,9 +1,28 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Sora:wght@300;400;500;600;700&display=swap');
 @import 'tailwindcss';
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+
+/* ── Design tokens ── */
+:root {
+  --rt-bg:            #0d1117;
+  --rt-surface:       #161b22;
+  --rt-surface2:      #1c2333;
+  --rt-border:        #30363d;
+  --rt-border-bright: #444c56;
+  --rt-text:          #e6edf3;
+  --rt-muted:         #7d8590;
+  --rt-dim:           #484f58;
+  --rt-flame:         #f78166;
+  --rt-sky:           #79c0ff;
+  --rt-leaf:          #3fb950;
+  --rt-amber:         #d29922;
+  --rt-ember:         #f85149;
+  --rt-orchid:        #bc8cff;
+}
 
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: var(--rt-bg);
+  color: var(--rt-text);
+  font-family: 'Sora', ui-sans-serif, system-ui, sans-serif;
 }

--- a/frontend/web/src/main.jsx
+++ b/frontend/web/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/web/src/pages/Dashboard.jsx
+++ b/frontend/web/src/pages/Dashboard.jsx
@@ -1,313 +1,310 @@
 import React from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import ReportView from './ReportView';
 import { apiGet, apiPost } from '../lib/api';
 
-export default function Dashboard({ username, email, targets, scanType, projectId }) {
+export default function Dashboard() {
+  const { projectId, runId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Scan config comes from navigation state set by ProjectWorkspace
+  const { targets = [], scanType = 'web', username = '' } = location.state || {};
+
   const [logs, setLogs] = React.useState([]);
-  const [scanStatus, setScanStatus] = React.useState('IDLE');
+  const [scanStatus, setScanStatus] = React.useState('RUNNING');
   const [pendingAction, setPendingAction] = React.useState(null);
   const [isModalOpen, setIsModalOpen] = React.useState(false);
-  const [scanStarted, setScanStarted] = React.useState(false);
   const [error, setError] = React.useState('');
   const [viewingReport, setViewingReport] = React.useState(false);
-  // runId is returned by POST /scans/start and used for all subsequent calls.
-  const [runId, setRunId] = React.useState(null);
-  // reportId is populated from the status response once the scan completes.
   const [reportId, setReportId] = React.useState(null);
   const terminalRef = React.useRef(null);
 
   // Auto-scroll terminal to bottom when new logs arrive
   React.useEffect(() => {
-      if (terminalRef.current) {
-          terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
-      }
+    if (terminalRef.current) {
+      terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
+    }
   }, [logs]);
 
-  // Polling effect — runs every 1 second once a scan has been started.
-  // Keyed on runId so it restarts cleanly after a reset.
+  // Polling — starts immediately because the scan was already launched in the workspace.
   React.useEffect(() => {
-      if (!scanStarted || !runId) return;
+    if (!runId) return;
 
-      const pollInterval = setInterval(async () => {
-          try {
-              const data = await apiGet(`/scans/${runId}/status`);
-
-              setLogs(data.logs || []);
-              setScanStatus(data.status);
-              setPendingAction(data.pending_action);
-              if (data.report_id) setReportId(data.report_id);
-
-              if (data.status === 'NEEDS_APPROVAL' && data.pending_action) {
-                  setIsModalOpen(true);
-              }
-
-              if (data.status === 'COMPLETED' || data.status === 'TERMINATED') {
-                  clearInterval(pollInterval);
-              }
-          } catch (err) {
-              console.error('Polling error:', err);
-              setError('Lost connection to backend');
-          }
-      }, 1000);
-
-      return () => clearInterval(pollInterval);
-  }, [scanStarted, runId]);
-
-  const handleBeginRecon = async () => {
-      setError('');
-
+    const pollInterval = setInterval(async () => {
       try {
-          // POST /scans/start → { run_id }
-          const data = await apiPost('/scans/start', {
-              project_id: projectId,
-              targets,
-              scan_type: scanType,
-          });
+        const data = await apiGet(`/scans/${runId}/status`);
 
-          setRunId(data.run_id);
-          setScanStarted(true);
+        setLogs(data.logs || []);
+        setScanStatus(data.status);
+        setPendingAction(data.pending_action);
+        if (data.report_id) setReportId(data.report_id);
+
+        if (data.status === 'NEEDS_APPROVAL' && data.pending_action) {
+          setIsModalOpen(true);
+        }
+
+        if (data.status === 'COMPLETED' || data.status === 'TERMINATED') {
+          clearInterval(pollInterval);
+        }
       } catch (err) {
-          console.error('Start scan error:', err);
-          setError(err.message || 'Could not connect to backend. Is the server running?');
+        console.error('Polling error:', err);
+        setError('Lost connection to backend');
       }
-  };
+    }, 1000);
+
+    return () => clearInterval(pollInterval);
+  }, [runId]);
 
   const handleApprove = async () => {
-      try {
-          const data = await apiPost(`/scans/${runId}/approve`);
-          if (data.success) {
-              setIsModalOpen(false);
-              setPendingAction(null);
-          }
-      } catch (err) {
-          console.error('Approve action error:', err);
-          setError('Failed to approve action');
+    try {
+      const data = await apiPost(`/scans/${runId}/approve`);
+      if (data.success) {
+        setIsModalOpen(false);
+        setPendingAction(null);
       }
+    } catch (err) {
+      console.error('Approve error:', err);
+      setError('Failed to approve action');
+    }
   };
 
   const handleDeny = async () => {
-      try {
-          const data = await apiPost(`/scans/${runId}/deny`);
-          if (data.success) {
-              setIsModalOpen(false);
-              setPendingAction(null);
-          } else {
-              setError('Failed to deny action');
-          }
-      } catch (err) {
-          console.error('Deny action error:', err);
-          setError('Failed to communicate denial to AI');
+    try {
+      const data = await apiPost(`/scans/${runId}/deny`);
+      if (data.success) {
+        setIsModalOpen(false);
+        setPendingAction(null);
+      } else {
+        setError('Failed to deny action');
       }
+    } catch (err) {
+      console.error('Deny error:', err);
+      setError('Failed to communicate denial to AI');
+    }
   };
 
   const handleKillSwitch = async () => {
-      try {
-          const data = await apiPost(`/scans/${runId}/kill`);
-          if (data.success) {
-              setScanStatus('TERMINATED');
-              setIsModalOpen(false);
-              setPendingAction(null);
-              setError('⚠️ Session Terminated by Emergency Switch');
-          } else {
-              setError('Failed to activate kill switch');
-          }
-      } catch (err) {
-          console.error('Kill switch error:', err);
-          setError('Failed to activate emergency stop');
+    try {
+      const data = await apiPost(`/scans/${runId}/kill`);
+      if (data.success) {
+        setScanStatus('TERMINATED');
+        setIsModalOpen(false);
+        setPendingAction(null);
+        setError('⚠️ Session Terminated by Emergency Switch');
+      } else {
+        setError('Failed to activate kill switch');
       }
+    } catch (err) {
+      console.error('Kill switch error:', err);
+      setError('Failed to activate emergency stop');
+    }
   };
 
-  // Reset is purely client-side — the run record stays in the DB for audit purposes.
-  const handleResetScan = () => {
-      setLogs([]);
-      setScanStatus('IDLE');
-      setPendingAction(null);
-      setIsModalOpen(false);
-      setScanStarted(false);
-      setRunId(null);
-      setReportId(null);
-      setError('');
-      setViewingReport(false);
+  // Return to the workspace's findings tab after a scan completes.
+  const handleReturnToWorkspace = () => {
+    navigate(`/projects/${projectId}?tab=findings`);
   };
 
-  // Helper function to determine log color based on content
   const getLogColor = (message) => {
-      if (message.includes('[ALERT]')) return 'text-yellow-400';
-      if (message.includes('[SUCCESS]')) return 'text-cyan-400';
-      return 'text-green-400';
+    if (message.includes('[ALERT]')) return '#d29922';
+    if (message.includes('[SUCCESS]')) return '#79c0ff';
+    return '#3fb950';
   };
 
-  // If user is viewing report, show ReportView instead of terminal.
   if (viewingReport) {
-      return (
-          <ReportView
-              targets={targets}
-              reportId={reportId}
-              runId={runId}
-              onStartNewScan={handleResetScan}
-          />
-      );
+    return (
+      <ReportView
+        targets={targets}
+        reportId={reportId}
+        runId={runId}
+        onStartNewScan={handleReturnToWorkspace}
+      />
+    );
   }
 
+  const isActive = scanStatus === 'RUNNING' || scanStatus === 'NEEDS_APPROVAL';
+
   return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
-          <div className="max-w-4xl w-full mx-4 p-8 bg-gray-800 text-white rounded-lg shadow-xl relative">
-              {/* Emergency Kill Switch Button */}
-              {(scanStatus === 'RUNNING' || scanStatus === 'NEEDS_APPROVAL') && (
-                  <button
-                      onClick={handleKillSwitch}
-                      className="absolute top-4 right-4 bg-red-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-700 transition-colors flex items-center gap-2 border-2 border-red-400 shadow-lg"
-                  >
-                      <span className="text-xl">🛑</span>
-                      <span>Emergency Stop</span>
-                  </button>
-              )}
-              
-              <div className="space-y-6">
-                  {/* Welcome Header */}
-                  <div className="text-center mb-8">
-                      <h1 className="text-3xl font-bold mb-2">
-                          Welcome, {username}
-                      </h1>
-                      {email && (
-                          <p className="text-gray-400">
-                              {email}
-                          </p>
-                      )}
-                  </div>
+    <div className="min-h-screen flex items-center justify-center p-4" style={{ background: '#0d1117' }}>
+      <div
+        className="w-full max-w-4xl mx-4 p-8 rounded-lg shadow-xl relative"
+        style={{ background: '#161b22', border: '1px solid #30363d' }}
+      >
+        {/* Emergency Kill Switch */}
+        {isActive && (
+          <button
+            onClick={handleKillSwitch}
+            className="absolute top-4 right-4 font-bold py-2 px-4 rounded-lg flex items-center gap-2 border-2 shadow-lg transition-opacity hover:opacity-85"
+            style={{ background: '#f85149', color: 'white', borderColor: 'rgba(248,81,73,0.6)' }}
+          >
+            <span className="text-xl">🛑</span>
+            <span>Emergency Stop</span>
+          </button>
+        )}
 
-                  {/* Engagement Target Header */}
-                  <div className="mb-6">
-                      <h3 className="text-xl font-semibold text-gray-300">
-                          Engagement Target: <span className="text-blue-400">{targets.join(', ')}</span>
-                      </h3>
-                  </div>
-
-                  {/* Status Indicator */}
-                  <div className="bg-gray-700 rounded-lg p-4 mb-6">
-                      <p className="text-lg text-gray-200">
-                          {scanStatus === 'IDLE' && '🟢 AI Agent Online - Waiting for Command'}
-                          {scanStatus === 'RUNNING' && '🔵 AI Agent Running - Scanning Target...'}
-                          {scanStatus === 'NEEDS_APPROVAL' && '🟡 AI Agent Paused - Awaiting Authorization'}
-                          {scanStatus === 'COMPLETED' && '✅ AI Agent Completed - Scan Finished'}
-                          {scanStatus === 'TERMINATED' && '🔴 AI Agent TERMINATED - Emergency Stop Activated'}
-                      </p>
-                  </div>
-
-                  {/* Error Display */}
-                  {error && (
-                      <div className="bg-red-900 bg-opacity-30 border border-red-500 rounded-lg p-4">
-                          <p className="text-red-400">{error}</p>
-                      </div>
-                  )}
-
-                  {/* Begin Button (shown before scan starts) */}
-                  {!scanStarted && (
-                      <button
-                          onClick={handleBeginRecon}
-                          className="w-full bg-blue-600 text-white font-bold py-4 rounded-lg hover:bg-blue-700 transition-colors text-lg"
-                      >
-                          Begin Reconnaissance
-                      </button>
-                  )}
-
-                  {/* Terminal Window (shown after scan starts) */}
-                  {scanStarted && (
-                      <div className="bg-black rounded-lg p-4 border-2 border-green-500">
-                          <div className="mb-2 flex items-center justify-between">
-                              <span className="text-green-400 font-mono text-sm">
-                                  root@ai-redteam:~#
-                              </span>
-                              <span className="text-green-400 font-mono text-xs">
-                                  Status: {scanStatus}
-                              </span>
-                          </div>
-                          <div 
-                              ref={terminalRef}
-                              className="h-96 overflow-y-auto text-green-400 font-mono text-sm space-y-1"
-                          >
-                              {logs.length === 0 ? (
-                                  <p className="text-green-500 animate-pulse">Initializing AI Agent...</p>
-                              ) : (
-                                  logs.map((log, index) => (
-                                      <div key={index} className="hover:bg-gray-900">
-                                          <span className="text-green-600">
-                                              [{new Date(log.timestamp).toLocaleTimeString()}]
-                                          </span>
-                                          {' '}
-                                          <span className={getLogColor(log.message)}>
-                                              {log.message}
-                                          </span>
-                                      </div>
-                                  ))
-                              )}
-                              {scanStatus === 'RUNNING' && (
-                                  <p className="text-green-500 animate-pulse">▊</p>
-                              )}
-                          </div>
-                      </div>
-                  )}
-
-                  {/* View Report Button (shown when scan is completed) */}
-                  {scanStatus === 'COMPLETED' && !viewingReport && (
-                      <button
-                          onClick={() => setViewingReport(true)}
-                          className="w-full bg-green-600 text-white font-bold py-4 rounded-lg hover:bg-green-700 transition-colors text-lg mt-6"
-                      >
-                          📄 View Security Assessment Report
-                      </button>
-                  )}
-              </div>
+        <div className="space-y-6">
+          {/* Header */}
+          <div className="text-center mb-8">
+            <h1 className="text-2xl font-bold mb-1" style={{ color: '#e6edf3' }}>
+              Scan in Progress
+            </h1>
+            {username && (
+              <p className="text-sm" style={{ color: '#7d8590' }}>Running as {username}</p>
+            )}
           </div>
 
-          {/* HITL Modal Overlay */}
-          {isModalOpen && (
-              <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50">
-                  <div className="bg-gray-800 rounded-lg p-8 max-w-lg w-full mx-4 border-4 border-yellow-500 shadow-2xl">
-                      {/* Header */}
-                      <div className="text-center mb-6">
-                          <h2 className="text-3xl font-bold text-yellow-400 mb-2">
-                              ⚠️ CRITICAL SAFETY INTERVENTION REQUIRED
-                          </h2>
-                          <p className="text-red-400 font-semibold">
-                              Human-in-the-Loop Authorization Needed
-                          </p>
-                      </div>
+          {/* Target display */}
+          <div className="mb-4">
+            <p className="text-sm font-semibold" style={{ color: '#7d8590' }}>
+              Target{targets.length > 1 ? 's' : ''}:{' '}
+              <span style={{ color: '#79c0ff', fontFamily: 'monospace' }}>{targets.join(', ')}</span>
+            </p>
+          </div>
 
-                      {/* Body */}
-                      <div className="bg-gray-900 rounded-lg p-6 mb-6">
-                          <p className="text-white text-lg mb-2">
-                              <span className="font-bold">Pending Action:</span>
-                          </p>
-                          <p className="text-yellow-300 text-xl font-mono">
-                              {pendingAction}
-                          </p>
-                      </div>
+          {/* Status indicator */}
+          <div
+            className="rounded-lg p-4"
+            style={{ background: '#1c2333', border: '1px solid #30363d' }}
+          >
+            <p className="text-sm" style={{ color: '#e6edf3' }}>
+              {scanStatus === 'RUNNING' && '🔵 AI Agent Running — Scanning Target…'}
+              {scanStatus === 'NEEDS_APPROVAL' && '🟡 AI Agent Paused — Awaiting Your Authorization'}
+              {scanStatus === 'COMPLETED' && '✅ Scan Complete — Review your findings below'}
+              {scanStatus === 'TERMINATED' && '🔴 Scan Terminated — Emergency Stop Activated'}
+            </p>
+          </div>
 
-                      <div className="bg-red-900 bg-opacity-30 border border-red-500 rounded-lg p-4 mb-6">
-                          <p className="text-red-300 text-sm">
-                              ⚠️ This action could have significant impact. Review carefully before proceeding.
-                          </p>
-                      </div>
-
-                      {/* Action Buttons */}
-                      <div className="flex gap-4">
-                          <button
-                              onClick={handleDeny}
-                              className="flex-1 bg-red-600 text-white font-bold py-3 px-6 rounded-lg hover:bg-red-700 transition-colors"
-                          >
-                              ❌ DENY
-                          </button>
-                          <button
-                              onClick={handleApprove}
-                              className="flex-1 bg-green-600 text-white font-bold py-3 px-6 rounded-lg hover:bg-green-700 transition-colors"
-                          >
-                              ✓ APPROVE
-                          </button>
-                      </div>
-                  </div>
-              </div>
+          {/* Error display */}
+          {error && (
+            <div
+              className="rounded-lg p-4 text-sm"
+              style={{ background: 'rgba(248,81,73,0.08)', border: '1px solid rgba(248,81,73,0.3)', color: '#f85149' }}
+            >
+              {error}
+            </div>
           )}
+
+          {/* Terminal window */}
+          <div
+            className="rounded-lg p-4 border-2"
+            style={{ background: '#000', borderColor: '#3fb950' }}
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <span className="font-mono text-sm" style={{ color: '#3fb950' }}>
+                root@ai-redteam:~#
+              </span>
+              <span className="font-mono text-xs" style={{ color: '#3fb950' }}>
+                {scanStatus}
+              </span>
+            </div>
+            <div
+              ref={terminalRef}
+              className="h-96 overflow-y-auto font-mono text-sm space-y-1"
+            >
+              {logs.length === 0 ? (
+                <p className="animate-pulse" style={{ color: '#3fb950' }}>Initializing AI Agent…</p>
+              ) : (
+                logs.map((log, index) => (
+                  <div key={index} className="hover:bg-gray-900">
+                    <span style={{ color: '#237a37' }}>
+                      [{new Date(log.timestamp).toLocaleTimeString()}]
+                    </span>{' '}
+                    <span style={{ color: getLogColor(log.message) }}>{log.message}</span>
+                  </div>
+                ))
+              )}
+              {scanStatus === 'RUNNING' && (
+                <p className="animate-pulse" style={{ color: '#3fb950' }}>▊</p>
+              )}
+            </div>
+          </div>
+
+          {/* Post-scan actions */}
+          {scanStatus === 'COMPLETED' && !viewingReport && (
+            <div className="flex gap-3 mt-4">
+              <button
+                onClick={() => setViewingReport(true)}
+                className="flex-1 font-bold py-3 rounded-lg transition-opacity hover:opacity-85"
+                style={{ background: '#3fb950', color: '#0d1117' }}
+              >
+                📄 View Full Report
+              </button>
+              <button
+                onClick={handleReturnToWorkspace}
+                className="flex-1 font-bold py-3 rounded-lg transition-colors"
+                style={{ background: '#1c2333', border: '1px solid #30363d', color: '#79c0ff' }}
+              >
+                ← Return to Project
+              </button>
+            </div>
+          )}
+
+          {scanStatus === 'TERMINATED' && (
+            <button
+              onClick={handleReturnToWorkspace}
+              className="w-full font-bold py-3 rounded-lg transition-colors"
+              style={{ background: '#1c2333', border: '1px solid #30363d', color: '#79c0ff' }}
+            >
+              ← Return to Project
+            </button>
+          )}
+        </div>
       </div>
+
+      {/* HITL Modal */}
+      {isModalOpen && (
+        <div
+          className="fixed inset-0 flex items-center justify-center z-50 p-4"
+          style={{ background: 'rgba(0,0,0,0.75)' }}
+        >
+          <div
+            className="rounded-lg p-8 w-full max-w-lg mx-4 shadow-2xl border-4"
+            style={{ background: '#161b22', borderColor: '#d29922' }}
+          >
+            <div className="text-center mb-6">
+              <h2 className="text-2xl font-bold mb-2" style={{ color: '#d29922' }}>
+                ⚠️ CRITICAL SAFETY INTERVENTION REQUIRED
+              </h2>
+              <p className="font-semibold" style={{ color: '#f85149' }}>
+                Human-in-the-Loop Authorization Needed
+              </p>
+            </div>
+
+            <div
+              className="rounded-lg p-6 mb-6"
+              style={{ background: '#0d1117', border: '1px solid #30363d' }}
+            >
+              <p className="text-sm font-bold mb-2" style={{ color: '#e6edf3' }}>Pending Action:</p>
+              <p className="text-lg font-mono" style={{ color: '#d29922' }}>{pendingAction}</p>
+            </div>
+
+            <div
+              className="rounded-lg p-4 mb-6 text-sm"
+              style={{ background: 'rgba(248,81,73,0.08)', border: '1px solid rgba(248,81,73,0.3)', color: '#f85149' }}
+            >
+              ⚠️ This action could have significant impact. Review carefully before proceeding.
+            </div>
+
+            <div className="flex gap-4">
+              <button
+                onClick={handleDeny}
+                className="flex-1 font-bold py-3 px-6 rounded-lg transition-opacity hover:opacity-85"
+                style={{ background: '#f85149', color: 'white' }}
+              >
+                ❌ DENY
+              </button>
+              <button
+                onClick={handleApprove}
+                className="flex-1 font-bold py-3 px-6 rounded-lg transition-opacity hover:opacity-85"
+                style={{ background: '#3fb950', color: '#0d1117' }}
+              >
+                ✓ APPROVE
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/web/src/pages/Dashboard.jsx
+++ b/frontend/web/src/pages/Dashboard.jsx
@@ -9,7 +9,7 @@ export default function Dashboard() {
   const location = useLocation();
 
   // Scan config comes from navigation state set by ProjectWorkspace
-  const { targets = [], scanType = 'web', username = '' } = location.state || {};
+  const { targets = [], username = '' } = location.state || {};
 
   const [logs, setLogs] = React.useState([]);
   const [scanStatus, setScanStatus] = React.useState('RUNNING');

--- a/frontend/web/src/pages/DashboardHome.jsx
+++ b/frontend/web/src/pages/DashboardHome.jsx
@@ -16,7 +16,7 @@ function relativeTime(isoStr) {
   return new Date(isoStr).toLocaleDateString();
 }
 
-export default function DashboardHome({ username }) {
+export default function DashboardHome({ }) {
   const navigate = useNavigate();
   const [projects, setProjects] = React.useState([]);
   const [loading, setLoading] = React.useState(true);

--- a/frontend/web/src/pages/DashboardHome.jsx
+++ b/frontend/web/src/pages/DashboardHome.jsx
@@ -16,7 +16,7 @@ function relativeTime(isoStr) {
   return new Date(isoStr).toLocaleDateString();
 }
 
-export default function DashboardHome({ }) {
+export default function DashboardHome() {
   const navigate = useNavigate();
   const [projects, setProjects] = React.useState([]);
   const [loading, setLoading] = React.useState(true);

--- a/frontend/web/src/pages/DashboardHome.jsx
+++ b/frontend/web/src/pages/DashboardHome.jsx
@@ -1,0 +1,397 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiGet, apiPost, apiDelete } from '../lib/api';
+
+// Infer a relative time label from an ISO date string.
+function relativeTime(isoStr) {
+  if (!isoStr) return null;
+  const diff = Date.now() - new Date(isoStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(isoStr).toLocaleDateString();
+}
+
+export default function DashboardHome({ username }) {
+  const navigate = useNavigate();
+  const [projects, setProjects] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState('');
+
+  // New project modal state
+  const [showModal, setShowModal] = React.useState(false);
+  const [newName, setNewName] = React.useState('');
+  const [creating, setCreating] = React.useState(false);
+  const [createError, setCreateError] = React.useState('');
+
+  // Delete confirmation
+  const [confirmDelete, setConfirmDelete] = React.useState(null);
+
+  const modalRef = React.useRef(null);
+  const inputRef = React.useRef(null);
+
+  React.useEffect(() => {
+    loadProjects();
+  }, []);
+
+  // Focus input when modal opens
+  React.useEffect(() => {
+    if (showModal) inputRef.current?.focus();
+  }, [showModal]);
+
+  async function loadProjects() {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await apiGet('/projects');
+      setProjects(data);
+    } catch (err) {
+      setError(`Could not load projects: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCreateProject() {
+    const name = newName.trim();
+    if (!name || creating) return;
+    setCreating(true);
+    setCreateError('');
+    try {
+      const created = await apiPost('/projects', { name });
+      setProjects(prev => [...prev, created]);
+      setShowModal(false);
+      setNewName('');
+      navigate(`/projects/${created.id}`);
+    } catch (err) {
+      setCreateError(`Failed to create project: ${err.message}`);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDeleteProject(project) {
+    try {
+      await apiDelete(`/projects/${project.id}`);
+      setProjects(prev => prev.filter(p => p.id !== project.id));
+      setConfirmDelete(null);
+    } catch (err) {
+      setError(`Failed to delete project: ${err.message}`);
+      setConfirmDelete(null);
+    }
+  }
+
+  const totalProjects = projects.length;
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--rt-bg)' }}>
+      <div className="max-w-6xl mx-auto px-8 py-8">
+
+        {/* Page header */}
+        <div className="flex items-start justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold" style={{ color: 'var(--rt-text)', letterSpacing: '-0.5px' }}>
+              Dashboard
+            </h1>
+            <p className="text-sm mt-1" style={{ color: 'var(--rt-muted)' }}>
+              Overview of your security assessments
+            </p>
+          </div>
+          <button
+            onClick={() => setShowModal(true)}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-opacity hover:opacity-85"
+            style={{ background: 'var(--rt-sky)', color: '#0d1117' }}
+          >
+            <span className="text-base leading-none">+</span>
+            New Project
+          </button>
+        </div>
+
+        {/* Error banner */}
+        {error && (
+          <div
+            className="mb-6 flex items-start justify-between gap-3 px-4 py-3 rounded-lg text-sm"
+            style={{ background: 'rgba(248,81,73,0.08)', border: '1px solid rgba(248,81,73,0.3)', color: 'var(--rt-ember)' }}
+          >
+            <span>{error}</span>
+            <button onClick={() => setError('')} className="text-xs underline flex-shrink-0">Dismiss</button>
+          </div>
+        )}
+
+        {/* Stats row */}
+        <div className="grid grid-cols-4 gap-4 mb-8">
+          <StatCard
+            label="Total Projects"
+            value={loading ? '—' : String(totalProjects)}
+            sub={loading ? 'Loading…' : totalProjects === 1 ? '1 project' : `${totalProjects} projects`}
+          />
+          <StatCard label="Critical Findings" value="—" sub="TBD" accent="var(--rt-ember)" />
+          <StatCard label="Scans Run" value="—" sub="TBD" accent="var(--rt-amber)" />
+          <StatCard label="Reports Exported" value="—" sub="TBD" accent="var(--rt-leaf)" />
+        </div>
+
+        {/* Projects section */}
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold" style={{ color: 'var(--rt-text)' }}>Your Projects</h2>
+        </div>
+
+        {loading ? (
+          <div className="grid grid-cols-3 gap-4 mb-8">
+            {[1, 2, 3].map(i => (
+              <div
+                key={i}
+                className="rounded-lg animate-pulse"
+                style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)', height: '140px' }}
+              />
+            ))}
+          </div>
+        ) : projects.length === 0 ? (
+          <div
+            className="rounded-lg mb-8 py-16 text-center"
+            style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+          >
+            <p className="text-3xl mb-3 opacity-30">📁</p>
+            <p className="text-sm font-semibold mb-1" style={{ color: 'var(--rt-muted)' }}>No projects yet</p>
+            <p className="text-xs mb-5" style={{ color: 'var(--rt-dim)' }}>Create a project to start your first security assessment.</p>
+            <button
+              onClick={() => setShowModal(true)}
+              className="px-5 py-2 rounded-lg text-sm font-semibold transition-opacity hover:opacity-85"
+              style={{ background: 'var(--rt-sky)', color: '#0d1117' }}
+            >
+              + Create your first project
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+            {projects.map(project => (
+              <ProjectCard
+                key={project.id}
+                project={project}
+                onOpen={() => navigate(`/projects/${project.id}`)}
+                onDelete={() => setConfirmDelete(project)}
+              />
+            ))}
+            {/* New project card */}
+            <button
+              onClick={() => setShowModal(true)}
+              className="rounded-lg flex flex-col items-center justify-center gap-2 min-h-[130px] transition-colors"
+              style={{
+                background: 'transparent',
+                border: '1px dashed var(--rt-border)',
+                color: 'var(--rt-muted)',
+              }}
+              onMouseEnter={e => { e.currentTarget.style.borderColor = 'var(--rt-border-bright)'; e.currentTarget.style.color = 'var(--rt-text)'; }}
+              onMouseLeave={e => { e.currentTarget.style.borderColor = 'var(--rt-border)'; e.currentTarget.style.color = 'var(--rt-muted)'; }}
+            >
+              <span className="text-2xl opacity-40">＋</span>
+              <span className="text-sm font-medium">Create new project</span>
+            </button>
+          </div>
+        )}
+
+        {/* Activity feed */}
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold" style={{ color: 'var(--rt-text)' }}>Recent Activity</h2>
+        </div>
+        <div
+          className="rounded-lg overflow-hidden"
+          style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+        >
+          <div className="py-12 text-center">
+            <p className="text-2xl mb-3 opacity-20">📋</p>
+            <p className="text-sm font-medium mb-1" style={{ color: 'var(--rt-muted)' }}>Activity log coming soon</p>
+            <p className="text-xs" style={{ color: 'var(--rt-dim)' }}>Scan events, HITL approvals, and report exports will appear here.</p>
+          </div>
+        </div>
+
+      </div>
+
+      {/* New Project Modal */}
+      {showModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style={{ background: 'rgba(0,0,0,0.7)' }}
+          onClick={e => { if (e.target === e.currentTarget) { setShowModal(false); setNewName(''); setCreateError(''); } }}
+        >
+          <div
+            ref={modalRef}
+            className="w-full max-w-sm rounded-xl p-6 shadow-2xl"
+            style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border-bright)' }}
+          >
+            <h2 className="text-base font-bold mb-1" style={{ color: 'var(--rt-text)' }}>New Project</h2>
+            <p className="text-xs mb-5" style={{ color: 'var(--rt-muted)' }}>
+              Give your engagement a clear, descriptive name.
+            </p>
+
+            {createError && (
+              <p className="text-xs mb-3 px-3 py-2 rounded" style={{ background: 'rgba(248,81,73,0.1)', color: 'var(--rt-ember)' }}>
+                {createError}
+              </p>
+            )}
+
+            <input
+              ref={inputRef}
+              type="text"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleCreateProject()}
+              placeholder="e.g. Juice Shop Assessment"
+              className="w-full px-3 py-2 rounded-lg text-sm mb-4 outline-none focus:ring-1 font-mono"
+              style={{
+                background: 'var(--rt-surface2)',
+                border: '1px solid var(--rt-border)',
+                color: 'var(--rt-text)',
+              }}
+              onFocus={e => { e.target.style.borderColor = 'var(--rt-sky)'; }}
+              onBlur={e => { e.target.style.borderColor = 'var(--rt-border)'; }}
+            />
+
+            <div className="flex gap-3">
+              <button
+                onClick={() => { setShowModal(false); setNewName(''); setCreateError(''); }}
+                className="flex-1 py-2 rounded-lg text-sm font-medium transition-colors"
+                style={{ background: 'var(--rt-surface2)', border: '1px solid var(--rt-border)', color: 'var(--rt-muted)' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreateProject}
+                disabled={!newName.trim() || creating}
+                className="flex-1 py-2 rounded-lg text-sm font-semibold transition-opacity hover:opacity-85 disabled:opacity-40 disabled:cursor-not-allowed"
+                style={{ background: 'var(--rt-sky)', color: '#0d1117' }}
+              >
+                {creating ? 'Creating…' : 'Create Project'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation modal */}
+      {confirmDelete && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style={{ background: 'rgba(0,0,0,0.7)' }}
+        >
+          <div
+            className="w-full max-w-sm rounded-xl p-6 shadow-2xl"
+            style={{ background: 'var(--rt-surface)', border: '1px solid rgba(248,81,73,0.4)' }}
+          >
+            <h2 className="text-base font-bold mb-2" style={{ color: 'var(--rt-text)' }}>Delete Project?</h2>
+            <p className="text-sm mb-5" style={{ color: 'var(--rt-muted)' }}>
+              This will permanently delete{' '}
+              <strong style={{ color: 'var(--rt-text)' }}>{confirmDelete.name}</strong> and all its
+              targets. This action cannot be undone.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setConfirmDelete(null)}
+                className="flex-1 py-2 rounded-lg text-sm font-medium"
+                style={{ background: 'var(--rt-surface2)', border: '1px solid var(--rt-border)', color: 'var(--rt-muted)' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => handleDeleteProject(confirmDelete)}
+                className="flex-1 py-2 rounded-lg text-sm font-semibold"
+                style={{ background: 'var(--rt-ember)', color: 'white' }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Subcomponents ──────────────────────────────────────────────────────────────
+
+function StatCard({ label, value, sub, accent }) {
+  return (
+    <div
+      className="rounded-lg px-5 py-4"
+      style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+    >
+      <p className="text-xs font-mono font-semibold uppercase tracking-widest mb-2" style={{ color: 'var(--rt-muted)' }}>
+        {label}
+      </p>
+      <p className="font-mono text-3xl font-bold leading-none mb-1" style={{ color: accent || 'var(--rt-text)' }}>
+        {value}
+      </p>
+      <p className="text-xs" style={{ color: 'var(--rt-dim)' }}>{sub}</p>
+    </div>
+  );
+}
+
+function ProjectCard({ project, onOpen, onDelete }) {
+  const [hovered, setHovered] = React.useState(false);
+
+  return (
+    <div
+      className="rounded-lg relative overflow-hidden cursor-pointer transition-colors"
+      style={{
+        background: hovered ? 'var(--rt-surface2)' : 'var(--rt-surface)',
+        border: `1px solid ${hovered ? 'var(--rt-border-bright)' : 'var(--rt-border)'}`,
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={onOpen}
+    >
+      {/* Top accent bar on hover */}
+      <div
+        className="absolute top-0 left-0 right-0 h-0.5 transition-opacity"
+        style={{
+          background: 'linear-gradient(90deg, var(--rt-sky), var(--rt-orchid))',
+          opacity: hovered ? 1 : 0,
+        }}
+      />
+
+      <div className="p-5">
+        <p className="text-sm font-semibold mb-1" style={{ color: 'var(--rt-text)' }}>
+          {project.name}
+        </p>
+        <p className="font-mono text-xs mb-4" style={{ color: 'var(--rt-muted)' }}>
+          {project.created_at ? `Created ${relativeTime(project.created_at)}` : 'New project'}
+        </p>
+
+        <div
+          className="flex items-center justify-between pt-3"
+          style={{ borderTop: '1px solid var(--rt-border)' }}
+        >
+          <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--rt-muted)' }}>
+            <span
+              className="w-2 h-2 rounded-full flex-shrink-0"
+              style={{ background: 'var(--rt-leaf)', boxShadow: '0 0 5px var(--rt-leaf)' }}
+            />
+            Active
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={e => { e.stopPropagation(); onDelete(); }}
+              className="text-xs px-2 py-1 rounded transition-colors"
+              style={{ color: 'var(--rt-dim)', border: '1px solid var(--rt-border)' }}
+              onMouseEnter={e => { e.currentTarget.style.color = 'var(--rt-ember)'; e.currentTarget.style.borderColor = 'rgba(248,81,73,0.4)'; }}
+              onMouseLeave={e => { e.currentTarget.style.color = 'var(--rt-dim)'; e.currentTarget.style.borderColor = 'var(--rt-border)'; }}
+              title="Delete project"
+            >
+              ✕
+            </button>
+            <button
+              onClick={e => { e.stopPropagation(); onOpen(); }}
+              className="text-xs font-medium transition-colors"
+              style={{ color: 'var(--rt-sky)' }}
+            >
+              Open →
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/web/src/pages/HowItWorks.jsx
+++ b/frontend/web/src/pages/HowItWorks.jsx
@@ -1,0 +1,313 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const STEPS = [
+  {
+    num: '01',
+    title: 'Create a Project',
+    color: 'var(--rt-sky)',
+    bg: 'rgba(121,192,255,0.1)',
+    border: 'rgba(121,192,255,0.2)',
+    body: (
+      <>
+        A <strong style={{ color: 'var(--rt-text)' }}>Project</strong> is the container for one
+        engagement — think of it as a named folder for a specific system or client you&apos;re
+        assessing. Give it a clear name (e.g. &quot;Juice Shop QA&quot; or &quot;Internal API
+        Audit&quot;) so you can track multiple engagements separately. Click{' '}
+        <strong style={{ color: 'var(--rt-sky)' }}>+ New Project</strong> from the dashboard to get
+        started.
+      </>
+    ),
+  },
+  {
+    num: '02',
+    title: 'Define Your Targets',
+    color: 'var(--rt-orchid)',
+    bg: 'rgba(188,140,255,0.08)',
+    border: 'rgba(188,140,255,0.2)',
+    body: (
+      <>
+        Inside your project, add one or more{' '}
+        <strong style={{ color: 'var(--rt-text)' }}>Targets</strong> — these are the URLs, IP
+        addresses, or CIDR ranges you have authorization to test. The system auto-detects the target
+        type. You can add multiple targets and scan them independently.{' '}
+        <strong style={{ color: 'var(--rt-ember)' }}>
+          Only add targets you own or have written permission to test.
+        </strong>
+      </>
+    ),
+  },
+  {
+    num: '03',
+    title: 'Configure & Launch a Scan',
+    color: 'var(--rt-amber)',
+    bg: 'rgba(210,153,34,0.08)',
+    border: 'rgba(210,153,34,0.2)',
+    body: (
+      <>
+        Go to the <strong style={{ color: 'var(--rt-text)' }}>Scan</strong> tab, choose a target,
+        and pick a scan mode.{' '}
+        <strong style={{ color: 'var(--rt-text)' }}>Passive mode</strong> (default) is
+        non-intrusive — it observes and fingerprints without sending attack payloads, safe for
+        production. <strong style={{ color: 'var(--rt-text)' }}>Active mode</strong> sends test
+        payloads and may trigger security alerts — use it only on isolated test environments. Type{' '}
+        <strong style={{ color: 'var(--rt-ember)' }}>I AUTHORIZE</strong> to confirm you have
+        permission, then hit Start Scan.
+      </>
+    ),
+  },
+  {
+    num: '04',
+    title: 'Approve or Deny High-Impact Actions (HITL Gate)',
+    color: 'var(--rt-ember)',
+    bg: 'rgba(248,81,73,0.07)',
+    border: 'rgba(248,81,73,0.2)',
+    body: (
+      <>
+        During a scan, the AI agent may propose{' '}
+        <strong style={{ color: 'var(--rt-text)' }}>high-impact actions</strong> — commands that
+        could modify state, disrupt services, or trigger alerts. The system will{' '}
+        <strong style={{ color: 'var(--rt-text)' }}>pause and prompt you</strong> to approve or
+        deny each one before it executes. This is the Human-in-the-Loop (HITL) gate — you are
+        always the final decision-maker. You can kill the entire scan at any time using the emergency
+        stop in the live terminal.
+      </>
+    ),
+  },
+  {
+    num: '05',
+    title: 'Review Findings & Export a Report',
+    color: 'var(--rt-leaf)',
+    bg: 'rgba(63,185,80,0.07)',
+    border: 'rgba(63,185,80,0.2)',
+    body: (
+      <>
+        After the scan completes, navigate to the{' '}
+        <strong style={{ color: 'var(--rt-text)' }}>Findings</strong> tab to review all discovered
+        vulnerabilities ranked by severity (Critical → Low). Each finding includes a description,
+        affected target, CVE reference where available, and AI-generated remediation guidance. When
+        ready, go to <strong style={{ color: 'var(--rt-text)' }}>Reports</strong> to export a
+        structured report as <strong style={{ color: 'var(--rt-sky)' }}>JSON</strong> or{' '}
+        <strong style={{ color: 'var(--rt-sky)' }}>PDF</strong>.
+      </>
+    ),
+  },
+];
+
+const CONCEPTS = [
+  {
+    icon: '🧠',
+    title: 'Local LLM — No Cloud',
+    body: 'All AI inference runs locally via Ollama (qwen3:8b). Your targets, scan data, and findings never leave your machine.',
+  },
+  {
+    icon: '📚',
+    title: 'RAG Pipeline',
+    body: 'The AI retrieves context from a local vector database (ChromaDB) seeded with security playbooks, OWASP docs, and prior scan outputs.',
+  },
+  {
+    icon: '🔒',
+    title: 'Severity Grades (A–F)',
+    body: 'Each project receives a letter grade based on the distribution of findings. A = clean, F = critical unresolved issues.',
+  },
+  {
+    icon: '⚖️',
+    title: 'Legal Responsibility',
+    body: 'Unauthorized security testing is a federal crime under the CFAA. The "I AUTHORIZE" confirmation is a legal acknowledgment — not a formality.',
+  },
+];
+
+const FAQS = [
+  {
+    q: "What's the difference between Passive and Active mode?",
+    a: "Passive mode observes and fingerprints without sending attack payloads — it's safe for production. Active mode sends real test payloads (e.g. SQL injection strings, fuzzing inputs) that may cause errors or trigger security alerts. Always use Active mode only on isolated test environments like DVWA or Juice Shop.",
+  },
+  {
+    q: 'Can I run multiple scans at the same time?',
+    a: 'Not currently. AI RedTeam is designed for single, controlled scan sessions. Running concurrent scans on the same machine would degrade LLM performance and make HITL gate management difficult. Parallel scan support is a planned future feature.',
+  },
+  {
+    q: 'Does the AI ever take action without my approval?',
+    a: 'No. Any action the AI agent classifies as "high-impact" — meaning it could modify remote state, disrupt a service, or trigger an alert — is gated behind the HITL modal. You must explicitly approve it before it executes. You can also kill the scan at any time.',
+  },
+  {
+    q: 'What scanning tools does it use under the hood?',
+    a: 'Currently: nmap for network/port scanning and Nikto for web server vulnerability scanning. SQLMap support is planned. All tools run as subprocesses and their output is parsed and fed back to the AI reasoning layer.',
+  },
+  {
+    q: 'Where is my data stored?',
+    a: 'All data — projects, targets, findings, reports, and scan logs — is stored in a local PostgreSQL database on your machine. LLM inference runs via Ollama locally. No data is transmitted to external servers.',
+  },
+];
+
+export default function HowItWorks({ onComplete }) {
+  const navigate = useNavigate();
+  const [openFaq, setOpenFaq] = React.useState(null);
+
+  const isOnboarding = typeof onComplete === 'function';
+
+  function handleCta() {
+    if (isOnboarding) {
+      onComplete();
+    } else {
+      navigate('/dashboard');
+    }
+  }
+
+  return (
+    <div
+      className="min-h-screen py-10 px-6"
+      style={{ background: isOnboarding ? 'var(--rt-bg)' : 'transparent' }}
+    >
+      <div className="max-w-3xl mx-auto">
+
+        {/* Header */}
+        <div className="mb-8">
+          {isOnboarding && (
+            <div className="mb-4 inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-mono font-semibold" style={{ background: 'rgba(121,192,255,0.1)', border: '1px solid rgba(121,192,255,0.25)', color: 'var(--rt-sky)' }}>
+              Step 3 of 3 — Operational Briefing
+            </div>
+          )}
+          <h1 className="text-2xl font-bold mb-2" style={{ color: 'var(--rt-text)', letterSpacing: '-0.5px' }}>
+            {isOnboarding ? 'Before You Begin — How AI RedTeam Works' : 'How It Works'}
+          </h1>
+          <p className="text-sm" style={{ color: 'var(--rt-muted)' }}>
+            {isOnboarding
+              ? 'Review this guide carefully. You must acknowledge it before accessing the platform.'
+              : 'A guided walkthrough of the AI RedTeam workflow.'}
+          </p>
+        </div>
+
+        {/* Intro banner */}
+        <div
+          className="rounded-xl p-5 mb-8 flex gap-4 items-start"
+          style={{ background: 'linear-gradient(135deg,rgba(121,192,255,0.08) 0%,rgba(188,140,255,0.06) 100%)', border: '1px solid rgba(121,192,255,0.2)' }}
+        >
+          <span className="text-3xl flex-shrink-0">⬡</span>
+          <div>
+            <p className="text-sm font-semibold mb-1" style={{ color: 'var(--rt-text)' }}>
+              AI RedTeam — Intelligent Penetration Testing Assistant
+            </p>
+            <p className="text-sm leading-relaxed" style={{ color: 'var(--rt-muted)' }}>
+              AI RedTeam lets you run professional-grade security assessments against{' '}
+              <strong style={{ color: 'var(--rt-text)' }}>systems you own or have explicit permission to test</strong>.
+              It combines a locally-hosted AI model (no data leaves your machine) with open-source
+              scanning tools and a human-in-the-loop approval system to keep you in control at every step.
+            </p>
+          </div>
+        </div>
+
+        {/* Step-by-step workflow */}
+        <p className="text-xs font-mono font-semibold uppercase tracking-widest mb-4" style={{ color: 'var(--rt-muted)' }}>
+          Workflow — Step by Step
+        </p>
+        <div className="flex flex-col gap-3 mb-10">
+          {STEPS.map(step => (
+            <div
+              key={step.num}
+              className="rounded-lg overflow-hidden flex"
+              style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+            >
+              <div
+                className="flex items-center justify-center px-5 flex-shrink-0"
+                style={{ background: step.bg, borderRight: `1px solid ${step.border}`, minWidth: '64px' }}
+              >
+                <span className="font-mono text-lg font-bold" style={{ color: step.color }}>{step.num}</span>
+              </div>
+              <div className="p-4">
+                <p className="text-sm font-semibold mb-1" style={{ color: 'var(--rt-text)' }}>{step.title}</p>
+                <p className="text-xs leading-relaxed" style={{ color: 'var(--rt-muted)' }}>{step.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Key concepts */}
+        <p className="text-xs font-mono font-semibold uppercase tracking-widest mb-4" style={{ color: 'var(--rt-muted)' }}>
+          Key Concepts
+        </p>
+        <div className="grid grid-cols-2 gap-3 mb-10">
+          {CONCEPTS.map(c => (
+            <div
+              key={c.title}
+              className="rounded-lg p-4"
+              style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+            >
+              <div className="text-xl mb-2">{c.icon}</div>
+              <p className="text-sm font-semibold mb-1" style={{ color: 'var(--rt-text)' }}>{c.title}</p>
+              <p className="text-xs leading-relaxed" style={{ color: 'var(--rt-muted)' }}>{c.body}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* FAQ */}
+        <p className="text-xs font-mono font-semibold uppercase tracking-widest mb-4" style={{ color: 'var(--rt-muted)' }}>
+          FAQ
+        </p>
+        <div
+          className="rounded-lg overflow-hidden mb-10"
+          style={{ border: '1px solid var(--rt-border)' }}
+        >
+          {FAQS.map((faq, i) => (
+            <div
+              key={i}
+              style={{ borderBottom: i < FAQS.length - 1 ? '1px solid var(--rt-border)' : 'none' }}
+            >
+              <button
+                onClick={() => setOpenFaq(openFaq === i ? null : i)}
+                className="w-full text-left px-5 py-4 flex items-center justify-between gap-3 transition-colors"
+                style={{ background: openFaq === i ? 'var(--rt-surface2)' : 'var(--rt-surface)', color: 'var(--rt-text)' }}
+              >
+                <span className="text-sm font-medium">{faq.q}</span>
+                <span
+                  className="text-xs flex-shrink-0 transition-transform"
+                  style={{ color: 'var(--rt-dim)', transform: openFaq === i ? 'rotate(180deg)' : 'none' }}
+                >
+                  ▾
+                </span>
+              </button>
+              {openFaq === i && (
+                <div
+                  className="px-5 py-4 text-xs leading-relaxed"
+                  style={{ color: 'var(--rt-muted)', borderTop: '1px solid var(--rt-border)', background: 'var(--rt-surface)' }}
+                >
+                  {faq.a}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* CTA */}
+        <div
+          className="rounded-xl p-6 text-center"
+          style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+        >
+          {isOnboarding ? (
+            <>
+              <p className="text-sm mb-1 font-semibold" style={{ color: 'var(--rt-text)' }}>
+                Ready to proceed?
+              </p>
+              <p className="text-xs mb-5" style={{ color: 'var(--rt-muted)' }}>
+                By continuing, you confirm that you understand the above and will only test systems
+                you own or have explicit written permission to test.
+              </p>
+            </>
+          ) : (
+            <p className="text-sm mb-5" style={{ color: 'var(--rt-muted)' }}>
+              Need a refresher? This guide is always available from the navigation bar.
+            </p>
+          )}
+          <button
+            onClick={handleCta}
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg font-semibold text-sm transition-opacity hover:opacity-85"
+            style={{ background: 'var(--rt-sky)', color: '#0d1117' }}
+          >
+            {isOnboarding ? "I understand — take me to the dashboard →" : "← Back to Dashboard"}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/frontend/web/src/pages/ProjectWorkspace.jsx
+++ b/frontend/web/src/pages/ProjectWorkspace.jsx
@@ -75,8 +75,8 @@ export default function ProjectWorkspace({ username }) {
   // Findings tab state
   const [findings, setFindings] = React.useState([]);
   const [loadingFindings, setLoadingFindings] = React.useState(false);
-  const [/*findingsError*/, setFindingsError] = React.useState('');
-  const [/*latestRunId*/, setLatestRunId] = React.useState(null);
+  //const [/*findingsError*/, setFindingsError] = React.useState('');
+  //const [/*latestRunId*/, setLatestRunId] = React.useState(null);
 
   // Reports tab state
   const [reports, setReports] = React.useState([]);

--- a/frontend/web/src/pages/ProjectWorkspace.jsx
+++ b/frontend/web/src/pages/ProjectWorkspace.jsx
@@ -56,7 +56,7 @@ export default function ProjectWorkspace({ username }) {
   const [targets, setTargets] = React.useState([]);
   const [allProjects, setAllProjects] = React.useState([]);
   const [loadingProject, setLoadingProject] = React.useState(true);
-  const [loadingTargets, setLoadingTargets] = React.useState(false);
+  //const [loadingTargets, setLoadingTargets] = React.useState(false);
   const [projectError, setProjectError] = React.useState('');
 
   // Add target form state
@@ -75,8 +75,8 @@ export default function ProjectWorkspace({ username }) {
   // Findings tab state
   const [findings, setFindings] = React.useState([]);
   const [loadingFindings, setLoadingFindings] = React.useState(false);
-  const [findingsError, setFindingsError] = React.useState('');
-  const [latestRunId, setLatestRunId] = React.useState(null);
+  const [/*findingsError*/, setFindingsError] = React.useState('');
+  const [/*latestRunId*/, setLatestRunId] = React.useState(null);
 
   // Reports tab state
   const [reports, setReports] = React.useState([]);

--- a/frontend/web/src/pages/ProjectWorkspace.jsx
+++ b/frontend/web/src/pages/ProjectWorkspace.jsx
@@ -75,8 +75,8 @@ export default function ProjectWorkspace({ username }) {
   // Findings tab state
   const [findings, setFindings] = React.useState([]);
   const [loadingFindings, setLoadingFindings] = React.useState(false);
-  //const [/*findingsError*/, setFindingsError] = React.useState('');
-  //const [/*latestRunId*/, setLatestRunId] = React.useState(null);
+  const [_findingsError, setFindingsError] = React.useState('');
+  const [_latestRunId, setLatestRunId] = React.useState(null);
 
   // Reports tab state
   const [reports, setReports] = React.useState([]);
@@ -123,14 +123,14 @@ export default function ProjectWorkspace({ username }) {
     if (activeTab === 'findings' && findings.length === 0 && !loadingFindings) {
       loadFindings();
     }
-  }, [activeTab]);
+  }, [activeTab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Load reports when switching to reports tab ───────────────────────────────
   React.useEffect(() => {
     if (activeTab === 'reports' && reports.length === 0 && !loadingReports) {
       loadReports();
     }
-  }, [activeTab]);
+  }, [activeTab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Close switcher on outside click ─────────────────────────────────────────
   React.useEffect(() => {

--- a/frontend/web/src/pages/ProjectWorkspace.jsx
+++ b/frontend/web/src/pages/ProjectWorkspace.jsx
@@ -1,0 +1,945 @@
+import React from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { apiGet, apiPost, apiDelete } from '../lib/api';
+
+// Infer target type from its value string.
+function inferTargetType(value) {
+  if (!value) return 'URL';
+  const v = value.trim();
+  if (/\/\d+$/.test(v)) return 'CIDR';
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(v)) return 'IP';
+  if (/^https?:\/\//i.test(v) || v.includes('/')) return 'URL';
+  return 'DOMAIN';
+}
+
+// Derive a security grade + color from a findings array.
+function computeGrade(findings) {
+  if (!findings || findings.length === 0) return { grade: 'A', color: 'var(--rt-leaf)', label: 'No issues found' };
+  if (findings.some(f => f.severity === 'critical')) return { grade: 'F', color: 'var(--rt-ember)', label: 'Critical risk' };
+  if (findings.some(f => f.severity === 'high')) return { grade: 'D', color: 'var(--rt-amber)', label: 'High risk' };
+  if (findings.some(f => f.severity === 'medium')) return { grade: 'C', color: 'var(--rt-amber)', label: 'Moderate risk' };
+  return { grade: 'B', color: 'var(--rt-sky)', label: 'Low risk' };
+}
+
+function relativeTime(isoStr) {
+  if (!isoStr) return null;
+  const diff = Date.now() - new Date(isoStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+// ── Severity badge styles ──────────────────────────────────────────────────────
+const SEV_STYLE = {
+  critical: { color: 'var(--rt-ember)', bg: 'rgba(248,81,73,0.15)', border: 'rgba(248,81,73,0.3)', leftBorder: 'var(--rt-ember)' },
+  high:     { color: 'var(--rt-amber)', bg: 'rgba(210,153,34,0.15)',  border: 'rgba(210,153,34,0.3)',  leftBorder: 'var(--rt-amber)' },
+  medium:   { color: 'var(--rt-sky)',   bg: 'rgba(121,192,255,0.12)', border: 'rgba(121,192,255,0.3)', leftBorder: 'var(--rt-sky)' },
+  low:      { color: 'var(--rt-leaf)',  bg: 'rgba(63,185,80,0.12)',   border: 'rgba(63,185,80,0.3)',   leftBorder: 'var(--rt-leaf)' },
+};
+const SEV_ORDER = ['critical', 'high', 'medium', 'low'];
+
+export default function ProjectWorkspace({ username }) {
+  const { projectId } = useParams();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Tab state — honours ?tab= query param (e.g. returning from terminal)
+  const initialTab = searchParams.get('tab') || 'targets';
+  const [activeTab, setActiveTab] = React.useState(initialTab);
+
+  // Project + target state
+  const [project, setProject] = React.useState(null);
+  const [targets, setTargets] = React.useState([]);
+  const [allProjects, setAllProjects] = React.useState([]);
+  const [loadingProject, setLoadingProject] = React.useState(true);
+  const [loadingTargets, setLoadingTargets] = React.useState(false);
+  const [projectError, setProjectError] = React.useState('');
+
+  // Add target form state
+  const [showAddTarget, setShowAddTarget] = React.useState(false);
+  const [newTargetValue, setNewTargetValue] = React.useState('');
+  const [addingTarget, setAddingTarget] = React.useState(false);
+
+  // Scan tab state
+  const [selectedTargetId, setSelectedTargetId] = React.useState('');
+  const [scanMode, setScanMode] = React.useState('passive');
+  const [scanType, setScanType] = React.useState('web');
+  const [authorization, setAuthorization] = React.useState('');
+  const [scanLaunching, setScanLaunching] = React.useState(false);
+  const [scanError, setScanError] = React.useState('');
+
+  // Findings tab state
+  const [findings, setFindings] = React.useState([]);
+  const [loadingFindings, setLoadingFindings] = React.useState(false);
+  const [findingsError, setFindingsError] = React.useState('');
+  const [latestRunId, setLatestRunId] = React.useState(null);
+
+  // Reports tab state
+  const [reports, setReports] = React.useState([]);
+  const [loadingReports, setLoadingReports] = React.useState(false);
+
+  // Project switcher
+  const [switcherOpen, setSwitcherOpen] = React.useState(false);
+  const switcherRef = React.useRef(null);
+
+  // Delete project
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+  const [deleting, setDeleting] = React.useState(false);
+
+  // Global error banner
+  const [error, setError] = React.useState('');
+
+  // ── Load project + targets + all-projects on mount ──────────────────────────
+  React.useEffect(() => {
+    async function init() {
+      setLoadingProject(true);
+      setProjectError('');
+      try {
+        const [projectsData, targetsData] = await Promise.all([
+          apiGet('/projects'),
+          apiGet(`/projects/${projectId}/targets`),
+        ]);
+        const found = projectsData.find(p => String(p.id) === String(projectId));
+        if (!found) { setProjectError('Project not found.'); return; }
+        setProject(found);
+        setAllProjects(projectsData);
+        setTargets(targetsData);
+        if (targetsData.length > 0) setSelectedTargetId(String(targetsData[0].id));
+      } catch (err) {
+        setProjectError(`Could not load project: ${err.message}`);
+      } finally {
+        setLoadingProject(false);
+      }
+    }
+    init();
+  }, [projectId]);
+
+  // ── Load findings when switching to findings tab ─────────────────────────────
+  React.useEffect(() => {
+    if (activeTab === 'findings' && findings.length === 0 && !loadingFindings) {
+      loadFindings();
+    }
+  }, [activeTab]);
+
+  // ── Load reports when switching to reports tab ───────────────────────────────
+  React.useEffect(() => {
+    if (activeTab === 'reports' && reports.length === 0 && !loadingReports) {
+      loadReports();
+    }
+  }, [activeTab]);
+
+  // ── Close switcher on outside click ─────────────────────────────────────────
+  React.useEffect(() => {
+    function handle(e) {
+      if (switcherRef.current && !switcherRef.current.contains(e.target)) setSwitcherOpen(false);
+    }
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, []);
+
+  async function loadFindings() {
+    setLoadingFindings(true);
+    setFindingsError('');
+    try {
+      // Try project-level findings endpoint first.
+      // Falls back to empty array if the endpoint doesn't exist yet.
+      const data = await apiGet(`/projects/${projectId}/findings`).catch(() => null);
+      if (data) {
+        setFindings(data.findings || data);
+        if (data.run_id) setLatestRunId(data.run_id);
+      }
+    } catch {
+      // Findings endpoint not yet available — silently degrade
+    } finally {
+      setLoadingFindings(false);
+    }
+  }
+
+  async function loadReports() {
+    setLoadingReports(true);
+    try {
+      const data = await apiGet(`/projects/${projectId}/reports`).catch(() => []);
+      setReports(Array.isArray(data) ? data : []);
+    } finally {
+      setLoadingReports(false);
+    }
+  }
+
+  // ── Target CRUD ──────────────────────────────────────────────────────────────
+  async function handleAddTarget() {
+    const value = newTargetValue.trim();
+    if (!value || addingTarget) return;
+    setAddingTarget(true);
+    const temp = { id: `temp-${Date.now()}`, value };
+    setTargets(prev => [...prev, temp]);
+    setNewTargetValue('');
+    setShowAddTarget(false);
+    try {
+      const created = await apiPost(`/projects/${projectId}/targets`, { value });
+      setTargets(prev => prev.map(t => (t.id === temp.id ? created : t)));
+      if (!selectedTargetId) setSelectedTargetId(String(created.id));
+    } catch (err) {
+      setTargets(prev => prev.filter(t => t.id !== temp.id));
+      setError(`Failed to add target: ${err.message}`);
+    } finally {
+      setAddingTarget(false);
+    }
+  }
+
+  async function handleRemoveTarget(target) {
+    setTargets(prev => prev.filter(t => t.id !== target.id));
+    if (String(target.id).startsWith('temp-')) return;
+    try {
+      await apiDelete(`/projects/${projectId}/targets/${target.id}`);
+    } catch (err) {
+      setTargets(prev => [...prev, target]);
+      setError(`Failed to remove target: ${err.message}`);
+    }
+  }
+
+  // ── Scan launch ──────────────────────────────────────────────────────────────
+  async function handleStartScan() {
+    if (authorization !== 'I AUTHORIZE' || !selectedTargetId || scanLaunching) return;
+    setScanLaunching(true);
+    setScanError('');
+
+    const selectedTarget = targets.find(t => String(t.id) === String(selectedTargetId));
+    const targetValues = selectedTarget ? [selectedTarget.value] : targets.map(t => t.value);
+
+    try {
+      const data = await apiPost('/scans/start', {
+        project_id: projectId,
+        targets: targetValues,
+        scan_type: scanType,
+      });
+      navigate(`/projects/${projectId}/runs/${data.run_id}`, {
+        state: { targets: targetValues, scanType, username },
+      });
+    } catch (err) {
+      setScanError(`Failed to start scan: ${err.message}`);
+      setScanLaunching(false);
+    }
+  }
+
+  // ── Delete project ──────────────────────────────────────────────────────────
+  async function handleDeleteProject() {
+    setDeleting(true);
+    try {
+      await apiDelete(`/projects/${projectId}`);
+      navigate('/dashboard');
+    } catch (err) {
+      setError(`Failed to delete project: ${err.message}`);
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
+  }
+
+  // ── JSON export ──────────────────────────────────────────────────────────────
+  function handleExportJSON(report) {
+    const blob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `report-${report.id || 'export'}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  // ── Loading / error screens ──────────────────────────────────────────────────
+  if (loadingProject) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--rt-bg)' }}>
+        <p className="text-sm animate-pulse" style={{ color: 'var(--rt-muted)' }}>Loading project…</p>
+      </div>
+    );
+  }
+
+  if (projectError) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4" style={{ background: 'var(--rt-bg)' }}>
+        <p className="text-sm" style={{ color: 'var(--rt-ember)' }}>{projectError}</p>
+        <button
+          onClick={() => navigate('/dashboard')}
+          className="text-sm underline"
+          style={{ color: 'var(--rt-sky)' }}
+        >
+          ← Back to Dashboard
+        </button>
+      </div>
+    );
+  }
+
+  const grade = computeGrade(findings);
+  const canLaunch = authorization === 'I AUTHORIZE' && selectedTargetId && !scanLaunching;
+
+  return (
+    <div className="flex flex-col min-h-screen" style={{ background: 'var(--rt-bg)' }}>
+
+      {/* ── Project topbar ───────────────────────────────────────────────────── */}
+      <div
+        className="flex items-center gap-4 px-7 py-3"
+        style={{ background: 'var(--rt-surface)', borderBottom: '1px solid var(--rt-border)' }}
+      >
+        <nav className="flex items-center gap-2 text-sm" style={{ color: 'var(--rt-muted)' }}>
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="transition-colors hover:underline"
+            style={{ color: 'var(--rt-sky)' }}
+          >
+            ← Dashboard
+          </button>
+          <span style={{ color: 'var(--rt-dim)' }}>/</span>
+          <span className="font-semibold" style={{ color: 'var(--rt-text)' }}>{project?.name}</span>
+        </nav>
+
+        <div className="flex-1" />
+
+        {/* Project switcher */}
+        <div className="relative" ref={switcherRef}>
+          <button
+            onClick={() => setSwitcherOpen(o => !o)}
+            className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-colors"
+            style={{ background: 'var(--rt-surface2)', border: '1px solid var(--rt-border)', color: 'var(--rt-text)' }}
+          >
+            <span className="max-w-[160px] truncate">{project?.name}</span>
+            <span className="text-xs" style={{ color: 'var(--rt-muted)' }}>▾</span>
+          </button>
+          {switcherOpen && (
+            <div
+              className="absolute right-0 top-9 w-56 rounded-lg overflow-hidden shadow-2xl z-50"
+              style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+            >
+              <p className="px-3 py-2 text-xs font-mono font-semibold uppercase tracking-widest" style={{ color: 'var(--rt-dim)' }}>
+                Switch Project
+              </p>
+              {allProjects.map(p => (
+                <button
+                  key={p.id}
+                  onClick={() => { setSwitcherOpen(false); navigate(`/projects/${p.id}`); }}
+                  className="w-full text-left px-3 py-2 text-sm transition-colors"
+                  style={{
+                    background: String(p.id) === String(projectId) ? 'rgba(121,192,255,0.08)' : 'transparent',
+                    color: String(p.id) === String(projectId) ? 'var(--rt-sky)' : 'var(--rt-text)',
+                  }}
+                >
+                  {p.name}
+                  {String(p.id) === String(projectId) && <span className="ml-2 text-xs" style={{ color: 'var(--rt-sky)' }}>✓</span>}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Workspace tab bar ────────────────────────────────────────────────── */}
+      <div
+        className="flex items-center px-7"
+        style={{ background: 'var(--rt-surface)', borderBottom: '1px solid var(--rt-border)' }}
+      >
+        {[
+          { id: 'targets',  label: 'Targets',  count: targets.length },
+          { id: 'scan',     label: 'Scan' },
+          { id: 'findings', label: 'Findings', count: findings.length || null },
+          { id: 'reports',  label: 'Reports',  count: reports.length || null },
+        ].map(tab => (
+          <WsTab
+            key={tab.id}
+            label={tab.label}
+            count={tab.count}
+            active={activeTab === tab.id}
+            onClick={() => setActiveTab(tab.id)}
+          />
+        ))}
+      </div>
+
+      {/* ── Global error banner ───────────────────────────────────────────────── */}
+      {error && (
+        <div
+          className="mx-7 mt-4 flex items-start justify-between gap-3 px-4 py-3 rounded-lg text-sm"
+          style={{ background: 'rgba(248,81,73,0.08)', border: '1px solid rgba(248,81,73,0.3)', color: 'var(--rt-ember)' }}
+        >
+          <span>{error}</span>
+          <button onClick={() => setError('')} className="text-xs underline flex-shrink-0">Dismiss</button>
+        </div>
+      )}
+
+      {/* ── Body: main + sidebar ─────────────────────────────────────────────── */}
+      <div className="flex flex-1 overflow-hidden">
+
+        {/* Main content */}
+        <div className="flex-1 overflow-y-auto px-7 py-7" style={{ background: 'var(--rt-bg)' }}>
+
+          {/* ────────────────────── TARGETS TAB ─────────────────────────────── */}
+          {activeTab === 'targets' && (
+            <div>
+              <div className="flex items-start justify-between mb-5">
+                <div>
+                  <h2 className="text-sm font-semibold" style={{ color: 'var(--rt-text)' }}>Targets</h2>
+                  <p className="text-xs mt-0.5" style={{ color: 'var(--rt-muted)' }}>
+                    URLs, IPs, or CIDR ranges in scope for this project
+                  </p>
+                </div>
+                <button
+                  onClick={() => setShowAddTarget(t => !t)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-opacity hover:opacity-85"
+                  style={{ background: 'var(--rt-sky)', color: '#0d1117' }}
+                >
+                  + Add Target
+                </button>
+              </div>
+
+              {targets.length === 0 ? (
+                <div
+                  className="rounded-lg py-16 text-center"
+                  style={{ border: '1px dashed var(--rt-border)' }}
+                >
+                  <p className="text-2xl mb-2 opacity-30">🎯</p>
+                  <p className="text-sm font-medium mb-1" style={{ color: 'var(--rt-muted)' }}>No targets yet</p>
+                  <p className="text-xs" style={{ color: 'var(--rt-dim)' }}>Add a URL, IP, or CIDR range to begin.</p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-2 mb-4">
+                  {targets.map(target => (
+                    <TargetRow
+                      key={target.id}
+                      target={target}
+                      onScan={() => { setSelectedTargetId(String(target.id)); setActiveTab('scan'); }}
+                      onRemove={() => handleRemoveTarget(target)}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {/* Add target inline form */}
+              {showAddTarget && (
+                <div
+                  className="rounded-lg p-4 mt-3"
+                  style={{ background: 'var(--rt-surface2)', border: '1px dashed var(--rt-border-bright)' }}
+                >
+                  <p className="text-xs font-semibold mb-3" style={{ color: 'var(--rt-muted)' }}>Add new target</p>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      autoFocus
+                      value={newTargetValue}
+                      onChange={e => setNewTargetValue(e.target.value)}
+                      onKeyDown={e => e.key === 'Enter' && handleAddTarget()}
+                      placeholder="e.g. https://example.com or 192.168.1.1"
+                      className="flex-1 px-3 py-2 rounded text-xs font-mono outline-none"
+                      style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)', color: 'var(--rt-text)' }}
+                      onFocus={e => { e.target.style.borderColor = 'var(--rt-sky)'; }}
+                      onBlur={e => { e.target.style.borderColor = 'var(--rt-border)'; }}
+                    />
+                    <button
+                      onClick={handleAddTarget}
+                      disabled={!newTargetValue.trim() || addingTarget}
+                      className="px-3 py-2 rounded text-xs font-semibold transition-opacity hover:opacity-85 disabled:opacity-40"
+                      style={{ background: 'var(--rt-sky)', color: '#0d1117' }}
+                    >
+                      Add
+                    </button>
+                    <button
+                      onClick={() => { setShowAddTarget(false); setNewTargetValue(''); }}
+                      className="px-3 py-2 rounded text-xs"
+                      style={{ background: 'transparent', border: '1px solid var(--rt-border)', color: 'var(--rt-muted)' }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ────────────────────── SCAN TAB ────────────────────────────────── */}
+          {activeTab === 'scan' && (
+            <div>
+              <div className="mb-5">
+                <h2 className="text-sm font-semibold" style={{ color: 'var(--rt-text)' }}>Launch Scan</h2>
+                <p className="text-xs mt-0.5" style={{ color: 'var(--rt-muted)' }}>Configure and start a new assessment run</p>
+              </div>
+
+              <div
+                className="rounded-lg p-6 max-w-xl"
+                style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+              >
+                {targets.length === 0 ? (
+                  <div className="text-center py-8">
+                    <p className="text-sm mb-2" style={{ color: 'var(--rt-muted)' }}>No targets configured</p>
+                    <button
+                      onClick={() => setActiveTab('targets')}
+                      className="text-sm underline"
+                      style={{ color: 'var(--rt-sky)' }}
+                    >
+                      Add targets first →
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    {/* Target selector */}
+                    <label className="block text-xs font-medium mb-2" style={{ color: 'var(--rt-muted)' }}>Select Target</label>
+                    <select
+                      value={selectedTargetId}
+                      onChange={e => setSelectedTargetId(e.target.value)}
+                      className="w-full px-3 py-2 rounded-lg text-xs font-mono mb-5 outline-none cursor-pointer"
+                      style={{ background: 'var(--rt-surface2)', border: '1px solid var(--rt-border)', color: 'var(--rt-text)' }}
+                    >
+                      {targets.map(t => (
+                        <option key={t.id} value={String(t.id)}>{t.value}</option>
+                      ))}
+                    </select>
+
+                    {/* Scan mode */}
+                    <label className="block text-xs font-medium mb-2" style={{ color: 'var(--rt-muted)' }}>Scan Mode</label>
+                    <div className="grid grid-cols-2 gap-2 mb-5">
+                      <ModeOption
+                        selected={scanMode === 'passive'}
+                        onClick={() => setScanMode('passive')}
+                        label="🔍 Passive"
+                        sub="Non-intrusive · default"
+                      />
+                      <ModeOption
+                        selected={scanMode === 'active'}
+                        onClick={() => setScanMode('active')}
+                        label="⚡ Active"
+                        sub="May trigger alerts"
+                      />
+                    </div>
+
+                    {/* Scan type */}
+                    <label className="block text-xs font-medium mb-2" style={{ color: 'var(--rt-muted)' }}>Scan Type</label>
+                    <div className="grid grid-cols-2 gap-2 mb-5">
+                      <ModeOption
+                        selected={scanType === 'web'}
+                        onClick={() => setScanType('web')}
+                        label="🌐 Web (URL)"
+                        sub="Nikto / HTTP"
+                      />
+                      <ModeOption
+                        selected={scanType === 'network'}
+                        onClick={() => setScanType('network')}
+                        label="🖥 Network (IP)"
+                        sub="nmap"
+                      />
+                    </div>
+
+                    {/* Auth gate */}
+                    <div
+                      className="rounded-lg p-3 mb-5"
+                      style={{ background: 'rgba(248,81,73,0.06)', border: '1px solid rgba(248,81,73,0.25)' }}
+                    >
+                      <p className="text-xs font-semibold mb-2 flex items-center gap-1" style={{ color: 'var(--rt-ember)' }}>
+                        ⚠ Unauthorized testing is a violation of the CFAA
+                      </p>
+                      <input
+                        type="text"
+                        value={authorization}
+                        onChange={e => setAuthorization(e.target.value)}
+                        placeholder='Type "I AUTHORIZE" to confirm permission'
+                        className="w-full px-3 py-2 rounded text-xs font-mono outline-none"
+                        style={{
+                          background: 'var(--rt-surface)',
+                          border: '1px solid rgba(248,81,73,0.3)',
+                          color: 'var(--rt-text)',
+                        }}
+                        onFocus={e => { e.target.style.borderColor = 'var(--rt-ember)'; }}
+                        onBlur={e => { e.target.style.borderColor = 'rgba(248,81,73,0.3)'; }}
+                      />
+                    </div>
+
+                    {/* Scan error */}
+                    {scanError && (
+                      <p className="text-xs mb-3 px-3 py-2 rounded" style={{ background: 'rgba(248,81,73,0.1)', color: 'var(--rt-ember)' }}>
+                        {scanError}
+                      </p>
+                    )}
+
+                    {/* Start Scan button */}
+                    <button
+                      onClick={handleStartScan}
+                      disabled={!canLaunch}
+                      className="w-full py-2.5 rounded-lg text-sm font-bold transition-opacity hover:opacity-85 disabled:opacity-40 disabled:cursor-not-allowed"
+                      style={{ background: 'var(--rt-leaf)', color: '#0d1117', letterSpacing: '0.02em' }}
+                    >
+                      {scanLaunching ? 'Launching…' : '▶ Start Scan'}
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* ────────────────────── FINDINGS TAB ────────────────────────────── */}
+          {activeTab === 'findings' && (
+            <div>
+              <div className="flex items-start justify-between mb-5">
+                <div>
+                  <h2 className="text-sm font-semibold" style={{ color: 'var(--rt-text)' }}>Findings</h2>
+                  <p className="text-xs mt-0.5" style={{ color: 'var(--rt-muted)' }}>
+                    {findings.length > 0 ? `${findings.length} issues found` : 'Vulnerabilities discovered during scans'}
+                  </p>
+                </div>
+              </div>
+
+              {loadingFindings ? (
+                <div className="py-12 text-center">
+                  <p className="text-sm animate-pulse" style={{ color: 'var(--rt-muted)' }}>Loading findings…</p>
+                </div>
+              ) : findings.length === 0 ? (
+                <div className="py-16 text-center" style={{ border: '1px dashed var(--rt-border)', borderRadius: '8px' }}>
+                  <p className="text-3xl mb-3 opacity-20">🔍</p>
+                  <p className="text-sm font-medium mb-1" style={{ color: 'var(--rt-muted)' }}>No findings yet</p>
+                  <p className="text-xs mb-5" style={{ color: 'var(--rt-dim)' }}>Run a scan to discover vulnerabilities in your targets.</p>
+                  <button
+                    onClick={() => setActiveTab('scan')}
+                    className="px-4 py-2 rounded-lg text-xs font-semibold transition-opacity hover:opacity-85"
+                    style={{ background: 'var(--rt-sky)', color: '#0d1117' }}
+                  >
+                    Go to Scan →
+                  </button>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  {SEV_ORDER.filter(sev => findings.some(f => f.severity === sev)).map(sev => (
+                    <React.Fragment key={sev}>
+                      {findings.filter(f => f.severity === sev).map(finding => (
+                        <FindingCard key={finding.id} finding={finding} />
+                      ))}
+                    </React.Fragment>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ────────────────────── REPORTS TAB ─────────────────────────────── */}
+          {activeTab === 'reports' && (
+            <div>
+              <div className="mb-5">
+                <h2 className="text-sm font-semibold" style={{ color: 'var(--rt-text)' }}>Reports</h2>
+                <p className="text-xs mt-0.5" style={{ color: 'var(--rt-muted)' }}>Generated assessment reports for this project</p>
+              </div>
+
+              {loadingReports ? (
+                <p className="text-sm animate-pulse" style={{ color: 'var(--rt-muted)' }}>Loading reports…</p>
+              ) : reports.length === 0 ? (
+                <div className="py-16 text-center" style={{ border: '1px dashed var(--rt-border)', borderRadius: '8px' }}>
+                  <p className="text-3xl mb-3 opacity-20">📄</p>
+                  <p className="text-sm font-medium mb-1" style={{ color: 'var(--rt-muted)' }}>No reports yet</p>
+                  <p className="text-xs" style={{ color: 'var(--rt-dim)' }}>Complete a scan to generate a report.</p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-3 max-w-xl">
+                  {reports.map((report, i) => (
+                    <div
+                      key={report.id || i}
+                      className="flex items-center gap-4 px-4 py-4 rounded-lg"
+                      style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+                    >
+                      <span className="text-3xl">📄</span>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold truncate" style={{ color: 'var(--rt-text)' }}>
+                          {report.title || `Scan Report — Run #${i + 1}`}
+                        </p>
+                        <p className="font-mono text-xs mt-0.5" style={{ color: 'var(--rt-muted)' }}>
+                          {report.created_at ? `Generated ${relativeTime(report.created_at)}` : ''}{report.summary ? ` · ${report.summary.slice(0, 40)}` : ''}
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => handleExportJSON(report)}
+                          className="px-2 py-1 rounded text-xs transition-colors"
+                          style={{ border: '1px solid var(--rt-border)', color: 'var(--rt-muted)' }}
+                          onMouseEnter={e => { e.currentTarget.style.borderColor = 'var(--rt-border-bright)'; e.currentTarget.style.color = 'var(--rt-text)'; }}
+                          onMouseLeave={e => { e.currentTarget.style.borderColor = 'var(--rt-border)'; e.currentTarget.style.color = 'var(--rt-muted)'; }}
+                        >
+                          JSON
+                        </button>
+                        <button
+                          className="px-2 py-1 rounded text-xs opacity-40 cursor-not-allowed"
+                          style={{ border: '1px solid var(--rt-border)', color: 'var(--rt-muted)' }}
+                          title="PDF export coming soon"
+                          disabled
+                        >
+                          PDF
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+        </div>
+
+        {/* ── Right sidebar ─────────────────────────────────────────────────── */}
+        <aside
+          className="w-80 flex-shrink-0 overflow-y-auto flex flex-col gap-6 p-6"
+          style={{ borderLeft: '1px solid var(--rt-border)', background: 'var(--rt-surface)' }}
+        >
+          {/* Project info */}
+          <div>
+            <p className="text-xs font-mono font-semibold uppercase tracking-widest mb-3" style={{ color: 'var(--rt-muted)' }}>
+              Project Info
+            </p>
+            <div className="flex flex-col gap-2">
+              <InfoRow label="Created" value={project?.created_at ? new Date(project.created_at).toLocaleDateString() : '—'} />
+              <InfoRow label="Owner" value={username || '—'} mono />
+              <InfoRow label="Targets" value={String(targets.length)} mono />
+            </div>
+          </div>
+
+          {/* Security grade */}
+          <div>
+            <p className="text-xs font-mono font-semibold uppercase tracking-widest mb-3" style={{ color: 'var(--rt-muted)' }}>
+              Security Grade
+            </p>
+            <div
+              className="rounded-lg p-4 text-center mb-3"
+              style={{ background: 'var(--rt-surface2)', border: '1px solid var(--rt-border)' }}
+            >
+              <p className="font-mono text-5xl font-bold leading-none mb-1" style={{ color: grade.color }}>
+                {findings.length > 0 ? grade.grade : '—'}
+              </p>
+              <p className="text-xs" style={{ color: 'var(--rt-muted)' }}>
+                {findings.length > 0 ? grade.label : 'Run a scan to get a grade'}
+              </p>
+            </div>
+            {findings.length > 0 && (
+              <p className="text-xs leading-relaxed" style={{ color: 'var(--rt-muted)' }}>
+                Grade is calculated from severity distribution across all findings in the latest scan.
+              </p>
+            )}
+          </div>
+
+          {/* Quick actions */}
+          <div>
+            <p className="text-xs font-mono font-semibold uppercase tracking-widest mb-3" style={{ color: 'var(--rt-muted)' }}>
+              Quick Actions
+            </p>
+            <div className="flex flex-col gap-2">
+              <SidebarBtn onClick={() => setActiveTab('scan')}>▶ New Scan Run</SidebarBtn>
+              <SidebarBtn onClick={() => setActiveTab('reports')}>⬇ Reports</SidebarBtn>
+              <SidebarBtn
+                onClick={() => setConfirmDelete(true)}
+                danger
+              >
+                ✕ Delete Project
+              </SidebarBtn>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      {/* ── Delete confirmation modal ──────────────────────────────────────── */}
+      {confirmDelete && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style={{ background: 'rgba(0,0,0,0.7)' }}
+        >
+          <div
+            className="w-full max-w-sm rounded-xl p-6 shadow-2xl"
+            style={{ background: 'var(--rt-surface)', border: '1px solid rgba(248,81,73,0.4)' }}
+          >
+            <h2 className="text-base font-bold mb-2" style={{ color: 'var(--rt-text)' }}>Delete Project?</h2>
+            <p className="text-sm mb-5" style={{ color: 'var(--rt-muted)' }}>
+              This will permanently delete <strong style={{ color: 'var(--rt-text)' }}>{project?.name}</strong> and all its
+              data. This action cannot be undone.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setConfirmDelete(false)}
+                className="flex-1 py-2 rounded-lg text-sm font-medium"
+                style={{ background: 'var(--rt-surface2)', border: '1px solid var(--rt-border)', color: 'var(--rt-muted)' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDeleteProject}
+                disabled={deleting}
+                className="flex-1 py-2 rounded-lg text-sm font-semibold disabled:opacity-60"
+                style={{ background: 'var(--rt-ember)', color: 'white' }}
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+function WsTab({ label, count, active, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors"
+      style={{
+        color: active ? 'var(--rt-sky)' : 'var(--rt-muted)',
+        background: 'transparent',
+        borderTop: 'none',
+        borderLeft: 'none',
+        borderRight: 'none',
+        borderBottom: active ? '2px solid var(--rt-sky)' : '2px solid transparent',
+        cursor: 'pointer',
+      }}
+    >
+      {label}
+      {count != null && count > 0 && (
+        <span
+          className="font-mono text-xs px-1.5 py-0.5 rounded-full"
+          style={{
+            background: active ? 'rgba(121,192,255,0.12)' : 'var(--rt-surface2)',
+            border: `1px solid ${active ? 'rgba(121,192,255,0.3)' : 'var(--rt-border)'}`,
+            color: active ? 'var(--rt-sky)' : 'var(--rt-muted)',
+          }}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function TargetRow({ target, onScan, onRemove }) {
+  const type = inferTargetType(target.value);
+  const isTemp = String(target.id).startsWith('temp-');
+  const typeColor = type === 'IP' || type === 'CIDR' ? 'var(--rt-orchid)' : 'var(--rt-sky)';
+  const typeBorder = type === 'IP' || type === 'CIDR' ? 'rgba(188,140,255,0.25)' : 'rgba(121,192,255,0.25)';
+  const typeBg = type === 'IP' || type === 'CIDR' ? 'rgba(188,140,255,0.1)' : 'rgba(121,192,255,0.1)';
+
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-3 rounded-lg transition-colors"
+      style={{ background: 'var(--rt-surface)', border: '1px solid var(--rt-border)' }}
+      onMouseEnter={e => { e.currentTarget.style.borderColor = 'var(--rt-border-bright)'; e.currentTarget.style.background = 'var(--rt-surface2)'; }}
+      onMouseLeave={e => { e.currentTarget.style.borderColor = 'var(--rt-border)'; e.currentTarget.style.background = 'var(--rt-surface)'; }}
+    >
+      <span
+        className="font-mono text-xs font-bold px-2 py-0.5 rounded flex-shrink-0"
+        style={{ color: typeColor, border: `1px solid ${typeBorder}`, background: typeBg, textTransform: 'uppercase' }}
+      >
+        {type}
+      </span>
+      <span className="font-mono text-xs flex-1 truncate" style={{ color: 'var(--rt-text)' }}>
+        {target.value}
+      </span>
+      {isTemp && <span className="text-xs opacity-50" style={{ color: 'var(--rt-sky)' }}>saving…</span>}
+      <div className="flex items-center gap-1.5 flex-shrink-0">
+        <button
+          onClick={onScan}
+          className="px-2 py-1 rounded text-xs transition-colors"
+          style={{ border: '1px solid var(--rt-border)', color: 'var(--rt-muted)' }}
+          onMouseEnter={e => { e.currentTarget.style.color = 'var(--rt-text)'; e.currentTarget.style.borderColor = 'var(--rt-border-bright)'; }}
+          onMouseLeave={e => { e.currentTarget.style.color = 'var(--rt-muted)'; e.currentTarget.style.borderColor = 'var(--rt-border)'; }}
+        >
+          Scan
+        </button>
+        <button
+          onClick={onRemove}
+          className="px-2 py-1 rounded text-xs transition-colors"
+          style={{ border: '1px solid var(--rt-border)', color: 'var(--rt-muted)' }}
+          onMouseEnter={e => { e.currentTarget.style.color = 'var(--rt-ember)'; e.currentTarget.style.borderColor = 'rgba(248,81,73,0.4)'; }}
+          onMouseLeave={e => { e.currentTarget.style.color = 'var(--rt-muted)'; e.currentTarget.style.borderColor = 'var(--rt-border)'; }}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ModeOption({ selected, onClick, label, sub }) {
+  return (
+    <button
+      onClick={onClick}
+      className="rounded-lg px-3 py-3 text-left transition-colors"
+      style={{
+        background: selected ? 'rgba(121,192,255,0.08)' : 'var(--rt-surface2)',
+        border: `1px solid ${selected ? 'var(--rt-sky)' : 'var(--rt-border)'}`,
+      }}
+    >
+      <span className="block text-xs font-semibold" style={{ color: selected ? 'var(--rt-sky)' : 'var(--rt-muted)' }}>
+        {label}
+      </span>
+      <span className="block font-mono text-xs mt-0.5" style={{ color: 'var(--rt-dim)' }}>{sub}</span>
+    </button>
+  );
+}
+
+function FindingCard({ finding }) {
+  const sev = finding.severity?.toLowerCase() || 'low';
+  const style = SEV_STYLE[sev] || SEV_STYLE.low;
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div
+      className="rounded-lg px-4 py-4 cursor-pointer transition-colors"
+      style={{
+        background: 'var(--rt-surface)',
+        border: `1px solid var(--rt-border)`,
+        borderLeft: `3px solid ${style.leftBorder}`,
+      }}
+      onMouseEnter={e => { e.currentTarget.style.background = 'var(--rt-surface2)'; }}
+      onMouseLeave={e => { e.currentTarget.style.background = 'var(--rt-surface)'; }}
+      onClick={() => setOpen(o => !o)}
+    >
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <p className="text-sm font-semibold" style={{ color: 'var(--rt-text)' }}>{finding.title}</p>
+        <span
+          className="font-mono text-xs font-bold px-2 py-0.5 rounded flex-shrink-0"
+          style={{ background: style.bg, color: style.color, textTransform: 'uppercase' }}
+        >
+          {sev}
+        </span>
+      </div>
+      <p className="text-xs mb-2" style={{ color: 'var(--rt-muted)' }}>{finding.content}</p>
+      <div className="flex items-center gap-3 font-mono text-xs" style={{ color: 'var(--rt-dim)' }}>
+        {finding.finding_type && <span>{finding.finding_type}</span>}
+        {finding.confidence && <span>· {finding.confidence}% confidence</span>}
+      </div>
+      {open && finding.evidence && (
+        <div className="mt-3 px-3 py-2 rounded font-mono text-xs" style={{ background: '#000', color: '#3fb950' }}>
+          {finding.evidence}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InfoRow({ label, value, mono }) {
+  return (
+    <div className="flex items-center justify-between text-xs">
+      <span style={{ color: 'var(--rt-muted)' }}>{label}</span>
+      <span className={mono ? 'font-mono font-medium' : 'font-medium'} style={{ color: 'var(--rt-text)' }}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function SidebarBtn({ children, onClick, danger }) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full px-3 py-2 rounded-lg text-sm text-center font-medium transition-colors"
+      style={{
+        background: 'var(--rt-surface2)',
+        border: `1px solid ${danger ? 'rgba(248,81,73,0.3)' : 'var(--rt-border)'}`,
+        color: danger ? 'var(--rt-ember)' : 'var(--rt-text)',
+      }}
+      onMouseEnter={e => { e.currentTarget.style.borderColor = danger ? 'rgba(248,81,73,0.6)' : 'var(--rt-border-bright)'; e.currentTarget.style.background = 'var(--rt-surface)'; }}
+      onMouseLeave={e => { e.currentTarget.style.borderColor = danger ? 'rgba(248,81,73,0.3)' : 'var(--rt-border)'; e.currentTarget.style.background = 'var(--rt-surface2)'; }}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
Replaces the single-screen ProjectScopeManager (which forced project creation, target management, scan config, and legal authorization all at once) with a two-screen architecture: a Dashboard home the user lands on after onboarding, and a Project Workspace the user opens per-project. Also introduces URL-based routing, a shared top nav, and a mandatory onboarding briefing step.
Login → EULA → How It Works → /dashboard → /projects/:id → /projects/:id/runs/:runId

added src/pages/DashboardHome.jsx
added src/pages/ProjectWorkspace.jsx
added src/pages/HowItWorks.jsx
src/components/TopNav.jsx

modified

src/App.jsx
src/main.jsx
src/pages/Dashboard.jsx

closes #105 
closes #106 
closees #107 
closes #108 
closes #109 
closes #110 
closes #111 