### PR TITLE
feat(agent): Standalone RAG node for all thinking nodes (#96)

### DIFF
--- a/service/redteam_agent/agent.py
+++ b/service/redteam_agent/agent.py
@@ -8,7 +8,8 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.types import interrupt
 from .config import config
 from .critic import CriticPipeline
-from .tools import retrieve_context, execute_nmap_scan, execute_msf_module, search_msf_modules
+from .rag_node import RAGNode
+from .tools import execute_nmap_scan, execute_msf_module, search_msf_modules
 
 VALID_PHASES = ("recon", "enumeration", "exploitation", "complete")
 PHASE_ORDER = {phase: i for i, phase in enumerate(VALID_PHASES)}
@@ -24,6 +25,10 @@ class MessagesState(TypedDict):
     findings: Annotated[list[dict], operator.add]
     last_tool_results: list[dict]
     phase_history: Annotated[list[str], operator.add]
+    # --- RAG inter-node communication ---
+    rag_query: str
+    rag_reason: str
+    rag_caller: str
 
 class RedTeamAgent:
     """
@@ -31,20 +36,24 @@ class RedTeamAgent:
 
     Graph flow:
         START -> planner -> tactician -> critic_node -> risk_gate_node -> tool_node -> analyst_node -> planner
+        Any thinking node (planner, tactician, critic, analyst) can request a RAG
+        search via rag_node, which routes results back to the calling node.
     The Planner decides *what* to do (phase + directive).
     The Tactician decides *how* to do it (tool calls).
     The Critic validates proposed commands (schema, scope, LLM review).
     The Risk Gate assesses danger level and requests operator approval for HIGH-risk actions.
     The Analyst interprets tool results to severity/risk levels.
+    The RAG Node retrieves knowledge from the vector store on behalf of thinking nodes.
     """
     def __init__(self):
         self._init_tools()
         self._init_models()
         self.critic = CriticPipeline(self.critic_model)
+        self.rag = RAGNode(self.rag_model)
         self.app = self._build_graph()
 
     def _init_tools(self):
-        self.tools = [retrieve_context, execute_nmap_scan, execute_msf_module, search_msf_modules]
+        self.tools = [execute_nmap_scan, execute_msf_module, search_msf_modules]
         self.tools_by_name = {tool.name: tool for tool in self.tools}
 
     def _init_models(self):
@@ -53,6 +62,7 @@ class RedTeamAgent:
         self.planner_model = ChatOllama(**config.LLM_CONFIG)
         self.critic_model = ChatOllama(**config.LLM_CONFIG)
         self.analyst_model = ChatOllama(**config.LLM_CONFIG)
+        self.rag_model = ChatOllama(**config.LLM_CONFIG)
 
     # --- Nodes ---
 
@@ -61,6 +71,7 @@ class RedTeamAgent:
 
         Analyses the full message history (tool outputs, findings, etc.) and
         returns a structured PHASE + DIRECTIVE that the Tactician will execute.
+        May request a RAG search first by outputting RAG_SEARCH + RAG_REASON.
         """
         phase_match, directive_match = None, None
         for _ in range(config.PLANNER_MAX_RETRIES):
@@ -69,10 +80,33 @@ class RedTeamAgent:
                 + state["messages"]
             )
             response = self._sanitize_response(raw_response).content
-            
+
+            # Check for RAG search request
+            rag_request = self._parse_rag_request(response)
+            if rag_request and self._recent_rag_count(state["messages"]) < config.MAX_RAG_PER_NODE:
+                return {
+                    "messages": [HumanMessage(content=f"[PLANNER \u2192 RAG] Searching: {rag_request[0]}")],
+                    "rag_query": rag_request[0],
+                    "rag_reason": rag_request[1],
+                    "rag_caller": "planner",
+                }
+
             # Parse PHASE and DIRECTIVE from response
             phase_match = re.search(r"PHASE:\s*(recon|enumeration|exploitation|complete)", response, re.IGNORECASE)
             directive_match = re.search(r"DIRECTIVE:\s*(.+)", response, re.DOTALL)
+
+            # Graceful fallback: if PHASE is "complete" but DIRECTIVE is missing,
+            # synthesize a reasonable completion directive instead of retrying.
+            if phase_match and phase_match.group(1).lower() == "complete" and not directive_match:
+                phase = "complete"
+                directive = "Engagement concluded — all viable exploitation approaches have been attempted."
+                return {
+                    "messages": [HumanMessage(content=f"[PLANNER — phase: {phase}]\n{directive}")],
+                    "current_phase": phase,
+                    "directive": directive,
+                    "phase_history": [phase],
+                }
+
             if not phase_match or not directive_match:
                 continue  # Retry
             phase = phase_match.group(1).lower()
@@ -93,19 +127,26 @@ class RedTeamAgent:
                 "phase_history": [phase],
             }
         # After exceeding MAX_PLANNER_RETRIES:
-        # Raise an error with details on what was missing for debugging
-        missing = []
-        if not phase_match:
-            missing.append("PHASE")
-        if not directive_match:
-            missing.append("DIRECTIVE")
-        raise ValueError(f"LLM response does not contain required format after {config.PLANNER_MAX_RETRIES} attempts. Missing: {', '.join(missing)}. Expected format: \nPHASE: <phase>\nDIRECTIVE: <directive>")
+        # Graceful fallback — mark engagement as complete instead of crashing.
+        # This typically happens when the context is very long and the LLM
+        # struggles to follow the strict format.
+        return {
+            "messages": [HumanMessage(
+                content="[PLANNER — phase: complete]\n"
+                        "Engagement concluded — planner could not produce a structured directive "
+                        "after maximum retries (likely due to extended context)."
+            )],
+            "current_phase": "complete",
+            "directive": "Engagement concluded (planner format fallback).",
+            "phase_history": ["complete"],
+        }
 
     def tactician_node(self, state: MessagesState):
         """Tactician: generates specific tool calls based on the Planner's directive.
 
         Reads the Planner's objective directly from message history and independently
         decides HOW to accomplish it — strategy is left to the Planner.
+        May request a RAG search first by outputting RAG_SEARCH + RAG_REASON.
         """
         response = self.tactician_model.invoke(
             [SystemMessage(content=config.TACTICIAN_SYSTEM_PROMPT)]
@@ -113,30 +154,49 @@ class RedTeamAgent:
         )
         response = self._sanitize_response(response)
 
+        # Check for RAG search request in text content
+        if response.content:
+            rag_request = self._parse_rag_request(response.content)
+            if rag_request and self._recent_rag_count(state["messages"]) < config.MAX_RAG_PER_NODE:
+                return {
+                    "messages": [HumanMessage(content=f"[TACTICIAN \u2192 RAG] Searching: {rag_request[0]}")],
+                    "rag_query": rag_request[0],
+                    "rag_reason": rag_request[1],
+                    "rag_caller": "tactician",
+                    "llm_calls": state.get('llm_calls', 0) + 1,
+                }
+
         return {
             "messages": [response],
             "llm_calls": state.get('llm_calls', 0) + 1
         }
 
     def tool_node(self, state: MessagesState):
-        """Performs the tool call"""
+        """Performs the tool call.
+
+        Uses ``_find_pending_action_msg`` to locate the most recent AI
+        message with unexecuted tool_calls, so that intermediate messages
+        (e.g. RAG search results) do not break the lookup.
+        """
         result = []
-        last_message = state["messages"][-1]
-        
-        if not hasattr(last_message, 'tool_calls'):
+        tc_message = self._find_pending_action_msg(state["messages"])
+
+        if not tc_message:
             return {"messages": []}
 
-        for tool_call in last_message.tool_calls:
-            tool = self.tools_by_name[tool_call["name"]]
+        for tool_call in tc_message.tool_calls:
+            tool = self.tools_by_name.get(tool_call["name"])
+            if not tool:
+                continue  # skip unknown tools (e.g. leftover retrieve_context)
             observation = tool.invoke(tool_call["args"])
-            
+
             # Handle potential artifact return (content, artifact)
             if isinstance(observation, tuple):
                 observation = observation[0]
-            
+
             result.append(ToolMessage(
-                content=str(observation), 
-                tool_call_id=tool_call["id"], 
+                content=str(observation),
+                tool_call_id=tool_call["id"],
                 name=tool_call["name"]
             ))
         return {
@@ -152,13 +212,46 @@ class RedTeamAgent:
 
         Performs Stage 1-3 validation only.  Risk-level gating (HIGH actions)
         is handled by the downstream ``risk_gate_node``.
+
+        Before running the 3 stages, automatically requests a RAG search for
+        the proposed commands so that Stage 3 (LLM review) has documentation
+        context.  If RAG results already exist after the current tool-call
+        message, the RAG step is skipped.
         """
-        if not hasattr(state["messages"][-1], "tool_calls") or not state["messages"][-1].tool_calls:
+        tc_message = self._find_pending_action_msg(state["messages"])
+        if not tc_message:
             return {"messages": []}
 
-        action_calls = [tc for tc in state["messages"][-1].tool_calls if tc["name"] != "retrieve_context"]
+        action_calls = [tc for tc in tc_message.tool_calls if tc["name"] != "retrieve_context"]
         if not action_calls:
             return {"messages": []}
+
+        # --- Auto-RAG: ensure we have documentation context ---
+        tc_idx = next(
+            i for i, m in enumerate(state["messages"]) if m is tc_message
+        )
+        has_rag = any(
+            isinstance(m, HumanMessage) and "[RAG SEARCH RESULT" in m.content
+            for m in state["messages"][tc_idx:]
+        )
+        if not has_rag:
+            query_parts = []
+            for tc in action_calls:
+                if tc["name"] == "execute_nmap_scan":
+                    cmd = tc["args"].get("command", "")
+                    flags = " ".join(p for p in cmd.split() if p.startswith("-"))
+                    query_parts.append(f"nmap {flags} usage and compatibility")
+                elif tc["name"] == "execute_msf_module":
+                    module = tc["args"].get("module_name", "")
+                    query_parts.append(f"metasploit module {module} usage and options")
+            if query_parts:
+                query = "; ".join(query_parts)
+                return {
+                    "messages": [HumanMessage(content=f"[CRITIC \u2192 RAG] Verifying: {query}")],
+                    "rag_query": query,
+                    "rag_reason": "Need documentation to validate proposed security tool commands for correctness and safety",
+                    "rag_caller": "critic_node",
+                }
 
         # --- Stage 1: Schema validation ---
         issues = []
@@ -225,12 +318,12 @@ class RedTeamAgent:
         only this node is re-executed — the expensive LLM review in
         ``critic_node`` is NOT repeated.
         """
-        if not hasattr(state["messages"][-1], "tool_calls") or not state["messages"][-1].tool_calls:
+        tc_message = self._find_pending_action_msg(state["messages"])
+        if not tc_message:
             return {"messages": []}
 
-
-        _SAFE_TOOLS = {"retrieve_context", "search_msf_modules"}
-        action_calls = [tc for tc in state["messages"][-1].tool_calls if tc["name"] not in _SAFE_TOOLS]
+        _SAFE_TOOLS = {"search_msf_modules"}
+        action_calls = [tc for tc in tc_message.tool_calls if tc["name"] not in _SAFE_TOOLS]
 
         high_calls = []
         for tc in action_calls:
@@ -261,9 +354,15 @@ class RedTeamAgent:
         return {"messages": []}
 
     def analyst_node(self, state: MessagesState):
-        """Analyst: interprets tool results and maps findings to severity/risk levels."""    
+        """Analyst: interprets tool results and maps findings to severity/risk levels.
+
+        May request a RAG search first to better understand tool outputs.
+        When re-entered after a RAG round-trip, the RAG results are included
+        in the prompt so the LLM knows what was already searched.
+        """    
         messages = state["messages"]
 
+        # Collect consecutive tool messages (most recent batch)
         tool_messages = []
         for m in reversed(messages):
             if isinstance(m, ToolMessage):
@@ -276,13 +375,47 @@ class RedTeamAgent:
         
         tool_summary = "\n\n".join(f"[{tm.name}]:\n{tm.content}" for tm in tool_messages)
 
+        # Collect any prior RAG results from this analyst invocation so the
+        # LLM knows what has already been searched and won't repeat the same
+        # RAG query.  We scan backwards from the tail of messages, collecting
+        # RAG SEARCH RESULT messages until we hit a non-RAG message.
+        prior_rag = []
+        for m in reversed(messages):
+            if isinstance(m, HumanMessage) and "[RAG SEARCH RESULT" in m.content:
+                prior_rag.append(m.content)
+            elif isinstance(m, HumanMessage) and "\u2192 RAG]" in m.content:
+                continue  # skip the RAG request message itself
+            else:
+                break
+        prior_rag.reverse()
+
+        prompt_parts = [f"TOOL OUTPUTS:\n{tool_summary}"]
+        if prior_rag:
+            prompt_parts.append(
+                "PRIOR RAG SEARCH RESULTS (already searched — do NOT repeat these queries, "
+                "use the information or proceed without it):\n"
+                + "\n---\n".join(prior_rag)
+            )
+
         analyst_response = self.analyst_model.invoke([
             SystemMessage(content=config.ANALYST_SYSTEM_PROMPT),
-            HumanMessage(content=f"TOOL OUTPUTS:\n{tool_summary}\n\n")
+            HumanMessage(content="\n\n".join(prompt_parts))
         ])
         analyst_response = self._sanitize_response(analyst_response)
-
         clean_content = analyst_response.content
+
+        # Check for RAG search request — but only if we haven't already exhausted retries
+        rag_request = self._parse_rag_request(clean_content)
+        if rag_request and not prior_rag and self._recent_rag_count(messages) < config.MAX_RAG_PER_NODE:
+            # First RAG attempt for this analyst invocation — allow it
+            return {
+                "messages": [HumanMessage(content=f"[ANALYST \u2192 RAG] Searching: {rag_request[0]}")],
+                "rag_query": rag_request[0],
+                "rag_reason": rag_request[1],
+                "rag_caller": "analyst_node",
+                "findings": [],
+            }
+
         findings = []
         for line in clean_content.split("\n"):
             if line.startswith("FINDING:"):
@@ -299,6 +432,58 @@ class RedTeamAgent:
         return {"messages": [analyst_message], "findings": findings}
     
     # --- Helpers ---
+
+    @staticmethod
+    def _find_pending_action_msg(messages: list):
+        """Return the most recent AI message whose tool_calls have not been executed.
+
+        Scans backward through *messages*.  Returns ``None`` if a
+        ``ToolMessage`` is encountered before an AI message with
+        ``tool_calls`` — that means the calls were already executed.
+        This allows nodes (critic, risk_gate, tool_node) to locate the
+        correct tool-call message even when RAG messages have been
+        inserted between the tactician output and the consuming node.
+        """
+        for m in reversed(messages):
+            if hasattr(m, "tool_calls") and m.tool_calls:
+                return m
+            if isinstance(m, ToolMessage):
+                return None  # tool_calls already executed
+        return None
+
+    @staticmethod
+    def _parse_rag_request(text: str):
+        """Parse ``RAG_SEARCH`` and ``RAG_REASON`` markers from LLM output.
+
+        Returns ``(query, reason)`` if found, ``None`` otherwise.
+        """
+        search_match = re.search(r"RAG_SEARCH:\s*(.+?)(?:\n|$)", text)
+        if not search_match:
+            return None
+        reason_match = re.search(r"RAG_REASON:\s*(.+?)(?:\n|$)", text)
+        query = search_match.group(1).strip()
+        reason = reason_match.group(1).strip() if reason_match else ""
+        return (query, reason)
+
+    @staticmethod
+    def _recent_rag_count(messages: list) -> int:
+        """Count consecutive RAG round-trips at the tail of *messages*.
+
+        Used to enforce ``MAX_RAG_PER_NODE`` and prevent infinite
+        RAG-search loops.
+        """
+        count = 0
+        for m in reversed(messages):
+            if isinstance(m, HumanMessage):
+                if "[RAG SEARCH RESULT" in m.content:
+                    count += 1
+                elif "\u2192 RAG]" in m.content:
+                    continue  # part of a RAG round-trip request
+                else:
+                    break
+            else:
+                break
+        return count
     
     @staticmethod
     def _strip_think_tags(text: str) -> str:
@@ -332,13 +517,14 @@ class RedTeamAgent:
         if response.content:
             updates["content"] = cls._strip_think_tags(response.content)
 
-        # Clean .tool_calls args
+        # Clean .tool_calls args (strip think tags from values AND
+        # whitespace from keys — qwen3 sometimes emits ' SMBPIPE' etc.)
         if hasattr(response, "tool_calls") and response.tool_calls:
             updates["tool_calls"] = [
                 {
                     **tc,
                     "args": {
-                        k: cls._strip_think_tags(v) if isinstance(v, str) else v
+                        k.strip(): cls._strip_think_tags(v) if isinstance(v, str) else v
                         for k, v in tc["args"].items()
                     },
                 }
@@ -349,27 +535,33 @@ class RedTeamAgent:
 
     # --- Conditional Edges ---
 
-    def route_after_planner(self, state: MessagesState) -> Literal["tactician", "__end__"]:
-        """After the Planner runs, decide whether to continue or finish."""
+    def route_after_planner(self, state: MessagesState) -> Literal["tactician", "rag_node", "__end__"]:
+        """After the Planner runs, decide whether to continue, RAG, or finish."""
+        if state.get("rag_query"):
+            return "rag_node"
         phase = state.get("current_phase", "recon")
         if phase == "complete":
             return END
         return "tactician"
 
-    def route_after_tactician(self, state: MessagesState) -> Literal["critic_node", "planner"]:
-        """After the Tactician runs, route based on whether tool calls were produced.
+    def route_after_tactician(self, state: MessagesState) -> Literal["critic_node", "planner", "rag_node"]:
+        """After the Tactician runs, route based on output.
 
+        - RAG search requested → rag_node.
         - Has tool_calls → send to Critic for validation.
-        - No tool_calls (LLM returned text instead of actions) → loop back to
-          Planner so it can re-evaluate the situation or advance the phase.
+        - No tool_calls (text only) → loop back to Planner.
         """
+        if state.get("rag_query"):
+            return "rag_node"
         last_message = state["messages"][-1]
         if hasattr(last_message, 'tool_calls') and last_message.tool_calls:
             return "critic_node"
         return "planner"
 
-    def route_after_critic(self, state: MessagesState) -> Literal["tactician", "risk_gate_node"]:
-        """After the Critic runs, either loop back to fix or proceed to risk gate."""
+    def route_after_critic(self, state: MessagesState) -> Literal["tactician", "risk_gate_node", "rag_node"]:
+        """After the Critic runs, route to RAG, loop back to fix, or proceed."""
+        if state.get("rag_query"):
+            return "rag_node"
         last_message = state["messages"][-1]
         if isinstance(last_message, HumanMessage) and "CRITICISM DETECTED" in last_message.content:
             return "tactician"
@@ -381,6 +573,17 @@ class RedTeamAgent:
         if isinstance(last_message, HumanMessage) and "CRITICISM DETECTED" in last_message.content:
             return "tactician"
         return "tool_node"
+
+    def route_after_analyst(self, state: MessagesState) -> Literal["planner", "rag_node"]:
+        """After the Analyst runs, route to RAG or back to Planner."""
+        if state.get("rag_query"):
+            return "rag_node"
+        return "planner"
+
+    def route_after_rag(self, state: MessagesState) -> Literal["planner", "tactician", "critic_node", "analyst_node"]:
+        """After the RAG node, route back to whichever node requested the search."""
+        caller = state.get("rag_caller", "planner")
+        return caller
 
     # --- Utilities ---
 
@@ -397,8 +600,16 @@ class RedTeamAgent:
     # --- Graph Construction ---
 
     def _build_graph(self):
-        """Build the StateGraph:
-        START → planner → tactician → critic_node → risk_gate_node → tool_node → analyst_node → planner
+        """Build the StateGraph with RAG support.
+
+        Main flow:
+            START → planner → tactician → critic_node → risk_gate_node → tool_node → analyst_node → planner
+
+        Any thinking node can detour to rag_node for knowledge retrieval:
+            planner     ↔ rag_node
+            tactician   ↔ rag_node
+            critic_node ↔ rag_node
+            analyst_node↔ rag_node
         """
         agent_builder = StateGraph(MessagesState)
 
@@ -409,38 +620,57 @@ class RedTeamAgent:
         agent_builder.add_node("risk_gate_node", self.risk_gate_node)
         agent_builder.add_node("tool_node", self.tool_node)
         agent_builder.add_node("analyst_node", self.analyst_node)
+        agent_builder.add_node("rag_node", self.rag)
 
-        # Add edges
-        
+        # ---- Edges ----
+
         # Entry point
         agent_builder.add_edge(START, "planner")
-        # Planner -> Tactician / END
+
+        # Planner → Tactician / RAG / END
         agent_builder.add_conditional_edges(
             "planner",
             self.route_after_planner,
-            {"tactician": "tactician", END: END},
+            {"tactician": "tactician", "rag_node": "rag_node", END: END},
         )
-        # Tactician -> Critic / Planner (no tool calls = let Planner re-evaluate)
+        # Tactician → Critic / Planner / RAG
         agent_builder.add_conditional_edges(
             "tactician",
             self.route_after_tactician,
-            {"critic_node": "critic_node", "planner": "planner"},
+            {"critic_node": "critic_node", "planner": "planner", "rag_node": "rag_node"},
         )
-        # Critic -> Risk Gate (passed) / Tactician (rejected)
+        # Critic → Risk Gate / Tactician / RAG
         agent_builder.add_conditional_edges(
             "critic_node",
             self.route_after_critic,
-            {"risk_gate_node": "risk_gate_node", "tactician": "tactician"},
+            {"risk_gate_node": "risk_gate_node", "tactician": "tactician", "rag_node": "rag_node"},
         )
-        # Risk Gate -> tool_node (approved) / Tactician (denied)
+        # Risk Gate → tool_node / Tactician  (unchanged, no RAG)
         agent_builder.add_conditional_edges(
             "risk_gate_node",
             self.route_after_risk_gate,
             {"tool_node": "tool_node", "tactician": "tactician"},
         )
-        # tool_node -> analyst_node -> planner
+        # tool_node → analyst_node
         agent_builder.add_edge("tool_node", "analyst_node")
-        agent_builder.add_edge("analyst_node", "planner")
+
+        # Analyst → Planner / RAG
+        agent_builder.add_conditional_edges(
+            "analyst_node",
+            self.route_after_analyst,
+            {"planner": "planner", "rag_node": "rag_node"},
+        )
+        # RAG → back to calling node
+        agent_builder.add_conditional_edges(
+            "rag_node",
+            self.route_after_rag,
+            {
+                "planner": "planner",
+                "tactician": "tactician",
+                "critic_node": "critic_node",
+                "analyst_node": "analyst_node",
+            },
+        )
 
         return agent_builder.compile(checkpointer=InMemorySaver())
 

--- a/service/redteam_agent/config.py
+++ b/service/redteam_agent/config.py
@@ -126,6 +126,15 @@ CRITICAL RESTRICTIONS — violation of these is itself an error:
 - Accept module_type='exploit' for any exploit module path.
 - LHOST, LPORT, PAYLOAD, ENCODER, TARGET are valid MSF console settings — never flag them as
   invalid options even if they are not listed in module.options.
+- RHOST and RHOSTS are interchangeable aliases in Metasploit. NEVER flag one as wrong in favor
+  of the other. Both are valid. Similarly, RPORT/RPORTS are interchangeable.
+- When a PRIOR tool execution error suggests a specific compatible payload (e.g., the runtime
+  listed compatible payloads), that information takes PRECEDENCE over documentation. The
+  documentation may be outdated or generic. If the message history shows a tool error like
+  "Payload X is NOT compatible... Compatible payloads: [Y, Z]", then Y and Z are VALID choices.
+- Documentation context is a GUIDE, not absolute truth. If the documentation mentions only
+  one payload example, that does NOT mean other payloads are invalid. Module runtime validation
+  is the authoritative source for option and payload compatibility.
 
 Rules:
 - If ALL proposed actions are compliant, reply ONLY with the string 'VALID'.
@@ -158,7 +167,13 @@ Decision Rules:
 
 You will receive the full message history so far (tool outputs, findings, etc.).
 
-You MUST reply in EXACTLY this format (no extra text):
+You MUST reply in EXACTLY one of these formats (no extra text):
+
+Format A — If you need technical documentation before deciding:
+RAG_SEARCH: <specific search query for documentation/guides>
+RAG_REASON: <one sentence explaining what you need and why>
+
+Format B — When you are ready to issue a directive:
 PHASE: <recon|enumeration|exploitation|complete>
 DIRECTIVE: <one-paragraph objective describing WHAT to find or achieve, not how to do it>
 """
@@ -169,7 +184,6 @@ accomplish it — selecting the right tools, parameters, and approach. Strategy 
 Planner's job; execution decisions are yours.
 
 Available Tools (you MUST only use these — do NOT suggest external commands like curl, smbclient, etc.):
-- `retrieve_context` — Search documentation / guides for usage instructions and constraints.
 - `execute_nmap_scan` — Run an Nmap scan (any scan type, any NSE script).
 - `search_msf_modules` — Search the live Metasploit module database for modules matching a keyword.
   Use this BEFORE execute_msf_module to verify a module path exists and find the correct full path.
@@ -212,12 +226,14 @@ Scan-Efficiency Rules (IMPORTANT — follow strictly to avoid timeouts):
 
 Rules:
 1. Read the Planner's objective and independently determine which tool(s) best achieve it.
-2. If this is your FIRST action in a new phase, call `retrieve_context` alongside your scan to get relevant documentation. This ensures your flags and syntax are correct.
-3. Fact Supremacy: Documentation retrieved via `retrieve_context` overrides your internal knowledge. If the docs say a flag is incompatible, you MUST follow that.
-4. Constraint Transparency: Before generating any command, explicitly list which flags/options are DISALLOWED per the documentation.
-5. Generate ONE round of tool call(s) that best accomplish the objective.
-6. Choose scans that actually PROBE the target. Passive list scans (`-sL`) are almost never useful.
-7. You MUST always respond with at least one tool call. NEVER respond with only text — your role is to EXECUTE, not advise. If you are unsure which tool to use, call `retrieve_context` to look up the correct approach.
+2. Fact Supremacy: Documentation retrieved via RAG overrides your internal knowledge. If the docs say a flag is incompatible, you MUST follow that.
+3. Constraint Transparency: Before generating any command, explicitly list which flags/options are DISALLOWED per the documentation.
+4. Generate ONE round of tool call(s) that best accomplish the objective.
+5. Choose scans that actually PROBE the target. Passive list scans (`-sL`) are almost never useful.
+6. You MUST always respond with EITHER tool calls OR a RAG_SEARCH request. NEVER respond with plain text only.
+7. If you need documentation before executing, output ONLY (no tool calls in the same response):
+   RAG_SEARCH: <specific search query for documentation/guides>
+   RAG_REASON: <one sentence explaining what you need and why>
 """
 
     ANALYST_SYSTEM_PROMPT = """You are a Cybersecurity Analyst specializing in vulnerability assessment and risk classification.
@@ -236,7 +252,13 @@ Instructions:
 2. Use your expertise to identify potential risks, vulnerabilities, or noteworthy findings.
 3. Provide a concise SUMMARY with an overall risk rating and recommended next action.
 
-Output Format:
+You MUST reply in EXACTLY one of these formats:
+
+Format A — If you need technical documentation to interpret the results:
+RAG_SEARCH: <specific search query for documentation/guides>
+RAG_REASON: <one sentence explaining what you need and why>
+
+Format B — When you are ready to provide your assessment:
 FINDING: [SEVERITY] <description>
 ...
 SUMMARY: <one-paragraph overall assessment and recommendation>
@@ -249,5 +271,30 @@ SUMMARY: <one-paragraph overall assessment and recommendation>
 
     # Planner retries for format enforcement
     PLANNER_MAX_RETRIES = 3
+
+    # Maximum consecutive RAG searches any single node can request before
+    # it is forced to produce a real decision.
+    MAX_RAG_PER_NODE = 3
+
+    RAG_NODE_SYSTEM_PROMPT = """You are a Knowledge Retrieval Specialist for a Red Team engagement assistant.
+
+You receive:
+1. A SEARCH QUERY — what the calling node is looking for.
+2. A SEARCH REASON — why the calling node needs this information.
+3. RETRIEVED DOCUMENTS — raw text chunks from the documentation database.
+
+Your task:
+1. Read all retrieved documents carefully.
+2. Based on the SEARCH REASON, identify the most relevant passages.
+3. Return a concise, structured excerpt containing ONLY the information relevant to the query and reason.
+4. Preserve technical details exactly (commands, flags, parameters, CVE numbers, module paths, etc.).
+5. If none of the retrieved documents are relevant, state that clearly.
+
+Output format:
+- One-line summary of what was found.
+- Relevant excerpts with source attribution.
+- Keep total output under 1500 characters.
+
+Do NOT add opinions or analysis — only extract and present what the documents contain."""
 
 config = RAGConfig()

--- a/service/redteam_agent/critic.py
+++ b/service/redteam_agent/critic.py
@@ -228,9 +228,13 @@ class CriticPipeline:
         proposed_summary = "\n".join(proposed_parts)
 
         # Retrieve the latest RAG context from message history
+        # Look for both legacy ToolMessage (retrieve_context) and new RAG node results.
         rag_context = ""
         for m in reversed(messages):
             if isinstance(m, ToolMessage) and m.name == "retrieve_context":
+                rag_context = m.content
+                break
+            if isinstance(m, HumanMessage) and "[RAG SEARCH RESULT" in m.content:
                 rag_context = m.content
                 break
 

--- a/service/redteam_agent/rag_node.py
+++ b/service/redteam_agent/rag_node.py
@@ -1,0 +1,88 @@
+"""RAG Node — standalone knowledge-retrieval node for the agent graph.
+
+Thinking nodes (Planner, Tactician, Critic, Analyst) request a RAG search
+by setting ``rag_query`` and ``rag_reason`` in the graph state.  This node
+performs a vector-store similarity search, uses an LLM to extract the most
+relevant excerpts, and appends the result to the message history before
+the graph routes back to the calling node.
+"""
+
+import re
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from .config import config
+from .vector_store import get_vector_store
+
+
+def _strip_think_tags(text: str) -> str:
+    """Remove qwen3 ``<think>`` artifacts from *text*."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+    text = re.sub(r"</?think>?", "", text)
+    text = re.sub(r"/think\b", "", text)
+    text = re.sub(r" {2,}", " ", text)
+    return text.strip()
+
+
+class RAGNode:
+    """Performs vector-store retrieval + LLM-based excerpt selection.
+
+    Parameters
+    ----------
+    llm_model
+        A LangChain-compatible chat model used for summarising / selecting
+        the most relevant fragments from retrieved documents.
+    """
+
+    def __init__(self, llm_model):
+        self.llm = llm_model
+
+    def __call__(self, state: dict) -> dict:
+        """Execute the RAG search and return results to the calling node."""
+        query = state.get("rag_query", "")
+        reason = state.get("rag_reason", "")
+
+        if not query:
+            return {
+                "messages": [HumanMessage(content="[RAG] No search query provided.")],
+                "rag_query": "",
+                "rag_reason": "",
+            }
+
+        # --- 1. Vector-store similarity search ---
+        vector_store = get_vector_store()
+        docs = vector_store.similarity_search(query, k=config.RETRIEVER_K)
+
+        if not docs:
+            return {
+                "messages": [HumanMessage(
+                    content=f"[RAG SEARCH RESULT — query: '{query}']\nNo relevant documents found."
+                )],
+                "rag_query": "",
+                "rag_reason": "",
+            }
+
+        raw_context = "\n\n---\n\n".join(
+            f"Source: {doc.metadata}\n{doc.page_content}" for doc in docs
+        )
+
+        # --- 2. LLM-based excerpt selection ---
+        prompt = (
+            f"SEARCH QUERY: {query}\n"
+            f"SEARCH REASON: {reason}\n\n"
+            f"RETRIEVED DOCUMENTS:\n{raw_context}"
+        )
+
+        response = self.llm.invoke([
+            SystemMessage(content=config.RAG_NODE_SYSTEM_PROMPT),
+            HumanMessage(content=prompt),
+        ])
+        summary = _strip_think_tags(response.content)
+
+        return {
+            "messages": [HumanMessage(
+                content=f"[RAG SEARCH RESULT — query: '{query}']\n{summary}"
+            )],
+            "rag_query": "",
+            "rag_reason": "",
+        }

--- a/service/test_agent_planner.py
+++ b/service/test_agent_planner.py
@@ -5,6 +5,8 @@
 
 import sys
 import os
+import datetime
+import atexit
 from langchain_core.messages import HumanMessage
 from redteam_agent import ingest_documents, get_agent, config
 from redteam_agent.vector_store import clear_vector_store
@@ -32,11 +34,68 @@ MAGENTA = lambda t: _c("35", t)
 BLUE    = lambda t: _c("34", t)
 BOLD    = lambda t: _c("1", t)
 
+class TeeOutput:
+    """Duplicates writes to both the original stream and a log file.
+    ANSI colour codes are preserved as-is in the log file — view with
+    'cat <file>' (Linux/macOS) or a terminal-aware viewer (e.g. 'less -R').
+    """
+    def __init__(self, original, log_file):
+        self._original = original
+        self._log = log_file
+
+    def write(self, data):
+        self._original.write(data)
+        self._log.write(data)
+        return len(data)
+
+    def flush(self):
+        self._original.flush()
+        self._log.flush()
+
+    def isatty(self):
+        return self._original.isatty()
+
+    def fileno(self):
+        return self._original.fileno()
+
+    @property
+    def encoding(self):
+        return self._original.encoding
+
+    @property
+    def errors(self):
+        return self._original.errors
+
+    def reconfigure(self, **kwargs):
+        pass  # Already configured by the underlying stream
+
+
+# ── Set up file logging (ANSI colour codes preserved) ──
+_log_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+os.makedirs(_log_dir, exist_ok=True)
+_timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+_log_path = os.path.join(_log_dir, f"test_agent_planner_{_timestamp}.log")
+_log_file = open(_log_path, "w", encoding="utf-8", errors="replace")
+atexit.register(_log_file.close)
+
+sys.stdout = TeeOutput(sys.stdout, _log_file)
+sys.stderr = TeeOutput(sys.stderr, _log_file)
+
+# Also capture interactive input prompts + user answers in the log
+_builtin_input = input
+def input(prompt=""):   # noqa: A001 — intentional shadow of built-in
+    response = _builtin_input(prompt)
+    # The prompt is already tee'd via stdout; just record the user's reply.
+    _log_file.write(prompt +response + "\n")
+    _log_file.flush()
+    return response
+
 
 def main():
     print(BOLD("=" * 60))
     print(BOLD("  AI RedTeam Agent — Planner / Tactician Manual Test"))
     print(BOLD("=" * 60))
+    print(f"\n  {YELLOW('📄 Log file:')} {_log_path}")
 
     print(f"\nConfiguration:")
     print(f"  Embedder : {config.EMBEDDING_MODEL_NAME}")
@@ -99,6 +158,9 @@ def main():
         "plan": "",
         "findings": [],
         "phase_history": [],
+        "rag_query": "",
+        "rag_reason": "",
+        "rag_caller": "",
     }
     config_run = {"configurable": {"thread_id": "test-1"}, "recursion_limit": 100}
 
@@ -146,6 +208,8 @@ def main():
                         label = GREEN(f"▶ TOOL (step {step})")
                     elif node_name == "analyst_node":
                         label = BLUE(f"📊 ANALYST (step {step})")
+                    elif node_name == "rag_node":
+                        label = BOLD(CYAN(f"🔍 RAG (step {step})"))
                     else:
                         label = f"  {node_name} (step {step})"
 


### PR DESCRIPTION
RAG retrieval was bundled as a regular tool -- LLM nodes would respond
without consulting documentation. This PR extracts it into a standalone
graph node with bidirectional edges to all thinking nodes.

### How it works
- Planner / Tactician / Analyst output `RAG_SEARCH:` markers -> routed
  to rag_node -> results appended -> control returns to caller
- Critic auto-triggers RAG before Stage 3 LLM review
- `MAX_RAG_PER_NODE` (default 3) prevents infinite loops

### Bug fixes from integration testing
- Analyst RAG loop (repeated same query 3x)
- Planner crash on long context (graceful fallback)
- Critic false rejections (RHOST/RHOSTS aliases, payload precedence)
- Whitespace in tool_call arg keys (`' SMBPIPE'`)

### Test script improvements
- `test_agent_planner.py` now logs full output (with ANSI colours) to
  `service/logs/` via TeeOutput for post-run analysis

### Testing
3 iterative test runs via `test_agent_planner.py`, 87 steps in final
run: recon → enumeration → exploitation → complete.

## Closed #96 